### PR TITLE
Add unique_id support for departures

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ sensor:
     vehicle_position_url: 'https://data.texas.gov/download/eiei-9rpf/application%2Foctet-stream'
     departures:
     - name: Downtown to airport
+      unique_id: 3f2f8b2e-8ed2-4d7c-b2a6-9a8f0911b7a9
       route: 100
       stopid: 514
 ```
@@ -40,6 +41,7 @@ sensor:
   vehicle_position_url: 'http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/1.pb?key=TEST'
   departures:
   - name: "48 to Uni"
+    unique_id: 8af3e2dd-9f0a-4b84-8ec0-109c9d2a7c4f
     route: 100228
     stopid: 36800
 ```
@@ -53,6 +55,7 @@ sensor:
   apikey: <api key>
   departures:
   - name: "Bus 178"
+    unique_id: 4b38ec0f-7b3e-47c2-9ee0-1f6a4c1c7f54
     route: 168
     stopid: 56698 
 ```
@@ -65,6 +68,7 @@ sensor:
     x_api_key: <api key>
     departures:
       - name: "Brooklyn F"
+        unique_id: 0b45f0b3-1b02-49c8-96a2-cdcb12183947
         route: 'F'
         stopid: 'F16S'
 ```
@@ -77,6 +81,7 @@ sensor:
     vehicle_position_url: 'https://cdn.mbta.com/realtime/VehiclePositions.pb'
     departures:
       - name: "MBTA Red Line Kendall/MIT to Ashmont/Braintree"
+        unique_id: 7e8c7d6a-5c9c-46c4-8ab0-2a4b5a1c9a74
         route: 'Red'
         stopid: '70071'
 ```
@@ -87,6 +92,7 @@ Configuration variables:
 - **vehicle_position_url** (*Optional*): Provides live bus position tracking on the home assistant map
 - **headers**(*Optional*): Expects a dictionary. If provided, the dictionary will be sent as headers. (e.g. {"Authorization": "mykey"})
 - **departures** (*Required*): A list of routes and departure locations to watch
+- **unique_id** (*Optional*): A UUID for the entity to allow entity registry entries
 - **route** (*Optional*): The name of the gtfs route
 - **stopid** (*Optional*): The stopid for the location you want etas for
 

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -7,7 +7,7 @@ from enum import Enum
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME, UnitOfTime
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME, CONF_UNIQUE_ID, UnitOfTime
 import homeassistant.util.dt as dt_util
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -51,6 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_VEHICLE_POSITION_URL): cv.string,
     vol.Optional(CONF_DEPARTURES): [{
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.uuid,
         vol.Required(CONF_STOP_ID): cv.string,
         vol.Required(CONF_ROUTE): cv.string
     }]
@@ -89,7 +90,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             data,
             departure.get(CONF_STOP_ID),
             departure.get(CONF_ROUTE),
-            departure.get(CONF_NAME)
+            departure.get(CONF_NAME),
+            departure.get(CONF_UNIQUE_ID)
         ))
 
     add_devices(sensors, True)
@@ -98,7 +100,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class PublicTransportSensor(SensorEntity):
     """Implementation of a public transport sensor."""
 
-    def __init__(self, data, stop, route, name):
+    def __init__(self, data, stop, route, name, unique_id):
         """Initialize the sensor."""
         self.data = data
         self._stop = stop
@@ -106,6 +108,7 @@ class PublicTransportSensor(SensorEntity):
 
         self._attr_name = name
         self._attr_icon = ICON
+        self._attr_unique_id = str(unique_id) if unique_id else None
         self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
 
     def _get_next_buses(self):


### PR DESCRIPTION
### Motivation
- Allow users to assign stable UUIDs to each departures entry so entities can be managed via the Home Assistant entity registry.
- Implement `unique_id` following Home Assistant formatting and validation rules to provide predictable entity identifiers.

### Description
- Added `CONF_UNIQUE_ID` import and schema support with `vol.Optional(CONF_UNIQUE_ID): cv.uuid` so `departures` accepts a `unique_id` UUID.
- Updated `setup_platform` to pass the `unique_id` from the config into `PublicTransportSensor` constructor.
- Extended `PublicTransportSensor` to accept `unique_id` and set `self._attr_unique_id = str(unique_id) if unique_id else None` so entities expose a Home Assistant `unique_id`.
- Updated `README.md` with example `unique_id` entries and added `unique_id` to the configuration variables list.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f263d6788320b165079115b90001)