### PR TITLE
Fix unique_id config validation

### DIFF
--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -51,7 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_VEHICLE_POSITION_URL): cv.string,
     vol.Optional(CONF_DEPARTURES): [{
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_UNIQUE_ID): cv.uuid,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Required(CONF_STOP_ID): cv.string,
         vol.Required(CONF_ROUTE): cv.string
     }]


### PR DESCRIPTION
### Motivation
- The platform attempted to validate `unique_id` with `cv.uuid`, which is not available in this environment and caused an `AttributeError`, so the schema should accept a string instead.

### Description
- Replace `vol.Optional(CONF_UNIQUE_ID): cv.uuid` with `vol.Optional(CONF_UNIQUE_ID): cv.string` in `custom_components/gtfs_rt/sensor.py` to avoid the missing `cv.uuid` attribute at import time.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f4754d688320aace7b25a949cd12)