### PR TITLE
Add schedule-aware GTFS health validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ sensor:
 - platform: gtfs_rt
   trip_update_url: 'http://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/1.pb?key=TEST'
   vehicle_position_url: 'http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/1.pb?key=TEST'
+  static_schedule_url: 'https://metro.kingcounty.gov/gtfs/google_transit.zip'
   departures:
   - name: "48 to Uni"
     unique_id: 8af3e2dd-9f0a-4b84-8ec0-109c9d2a7c4f
@@ -90,11 +91,20 @@ Configuration variables:
 
 - **trip_update_url** (*Required*): Provides bus route etas. See the **Finding Feeds** section at the bottom of the page for more details on how to find these
 - **vehicle_position_url** (*Optional*): Provides live bus position tracking on the home assistant map
+- **static_schedule_url** (*Optional*): A static GTFS ZIP feed used to validate whether a stop is valid and whether service should currently exist. When configured, the entity stays `unknown` during normal no-service windows, but becomes `unavailable` when the route/stop is invalid or scheduled service should exist and the realtime feed has no matching departures.
 - **headers**(*Optional*): Expects a dictionary. If provided, the dictionary will be sent as headers. (e.g. {"Authorization": "mykey"})
 - **departures** (*Required*): A list of routes and departure locations to watch
 - **unique_id** (*Optional*): A UUID for the entity to allow entity registry entries
 - **route** (*Optional*): The name of the gtfs route
 - **stopid** (*Optional*): The stopid for the location you want etas for
+
+When `static_schedule_url` is configured, each sensor also adds:
+
+- `Service status`
+- `Service today`
+- `Service expected now`
+- `Next scheduled departure`
+- `Problem reason`
 
 ## Screenshot
 

--- a/custom_components/gtfs_rt/health.py
+++ b/custom_components/gtfs_rt/health.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import io
+import logging
+import zipfile
+from collections import defaultdict
+from dataclasses import dataclass
+
+import requests
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SCHEDULE_REFRESH = dt.timedelta(hours=12)
+DEFAULT_ACTIVE_WINDOW_BEFORE = dt.timedelta(minutes=30)
+DEFAULT_ACTIVE_WINDOW_AFTER = dt.timedelta(minutes=90)
+
+STATUS_LOOKUP_FAILED = "schedule_lookup_failed"
+STATUS_INVALID_ROUTE = "invalid_route"
+STATUS_INVALID_STOP = "invalid_stop"
+STATUS_ROUTE_STOP_MISMATCH = "route_stop_mismatch"
+STATUS_NO_SERVICE_TODAY = "no_service_today"
+STATUS_NO_SERVICE_NOW = "no_service_now"
+STATUS_SERVICE_EXPECTED = "service_expected"
+
+
+def parse_gtfs_seconds(value: str) -> int:
+    """Parse a GTFS HH:MM:SS string into total seconds."""
+    hours, minutes, seconds = (int(part) for part in value.split(":"))
+    return hours * 3600 + minutes * 60 + seconds
+
+
+@dataclass(frozen=True)
+class ScheduleStatus:
+    status: str
+    route_exists: bool
+    stop_exists: bool
+    route_serves_stop: bool
+    service_today: bool
+    service_expected_now: bool
+    next_scheduled_departure: dt.datetime | None
+    problem_reason: str | None = None
+
+    @property
+    def is_config_problem(self) -> bool:
+        return self.status in {
+            STATUS_INVALID_ROUTE,
+            STATUS_INVALID_STOP,
+            STATUS_ROUTE_STOP_MISMATCH,
+        }
+
+
+class StaticScheduleValidator:
+    """Validate monitored route/stop pairs against a static GTFS feed."""
+
+    def __init__(
+        self,
+        schedule_url: str,
+        monitored_departures: list[tuple[str, str]],
+        headers: dict[str, str] | None = None,
+        refresh_interval: dt.timedelta = DEFAULT_SCHEDULE_REFRESH,
+        active_window_before: dt.timedelta = DEFAULT_ACTIVE_WINDOW_BEFORE,
+        active_window_after: dt.timedelta = DEFAULT_ACTIVE_WINDOW_AFTER,
+    ) -> None:
+        self._schedule_url = schedule_url
+        self._headers = headers or {}
+        self._refresh_interval = refresh_interval
+        self._active_window_before = active_window_before
+        self._active_window_after = active_window_after
+        self._monitored_routes = {route for route, _ in monitored_departures}
+        self._monitored_stops = {stop for _, stop in monitored_departures}
+
+        self._last_refresh: dt.datetime | None = None
+        self._route_ids: set[str] = set()
+        self._stop_ids: set[str] = set()
+        self._route_stop_service_ids: dict[tuple[str, str], set[str]] = defaultdict(set)
+        self._departures_by_service: dict[tuple[str, str, str], list[int]] = defaultdict(list)
+        self._calendar: dict[str, tuple[set[int], dt.date, dt.date]] = {}
+        self._calendar_exceptions: dict[dt.date, dict[str, bool]] = defaultdict(dict)
+
+    def get_status(self, route_id: str, stop_id: str, now: dt.datetime) -> ScheduleStatus:
+        """Return the schedule-aware health for a route/stop pair."""
+        try:
+            self._ensure_loaded(now)
+        except Exception as err:  # pragma: no cover - defensive fallback
+            _LOGGER.warning("Unable to validate static GTFS schedule: %s", err)
+            return ScheduleStatus(
+                status=STATUS_LOOKUP_FAILED,
+                route_exists=False,
+                stop_exists=False,
+                route_serves_stop=False,
+                service_today=False,
+                service_expected_now=False,
+                next_scheduled_departure=None,
+                problem_reason=str(err),
+            )
+
+        route_exists = route_id in self._route_ids
+        stop_exists = stop_id in self._stop_ids
+        route_serves_stop = bool(self._route_stop_service_ids.get((route_id, stop_id)))
+
+        if not route_exists:
+            return ScheduleStatus(
+                status=STATUS_INVALID_ROUTE,
+                route_exists=False,
+                stop_exists=stop_exists,
+                route_serves_stop=False,
+                service_today=False,
+                service_expected_now=False,
+                next_scheduled_departure=None,
+                problem_reason=f"Route {route_id} is not present in the static GTFS feed",
+            )
+
+        if not stop_exists:
+            return ScheduleStatus(
+                status=STATUS_INVALID_STOP,
+                route_exists=True,
+                stop_exists=False,
+                route_serves_stop=False,
+                service_today=False,
+                service_expected_now=False,
+                next_scheduled_departure=None,
+                problem_reason=f"Stop {stop_id} is not present in the static GTFS feed",
+            )
+
+        if not route_serves_stop:
+            return ScheduleStatus(
+                status=STATUS_ROUTE_STOP_MISMATCH,
+                route_exists=True,
+                stop_exists=True,
+                route_serves_stop=False,
+                service_today=False,
+                service_expected_now=False,
+                next_scheduled_departure=None,
+                problem_reason=f"Route {route_id} does not serve stop {stop_id} in the static GTFS feed",
+            )
+
+        service_ids = self._active_service_ids(now.date())
+        departures = [
+            departure_seconds
+            for service_id in service_ids
+            for departure_seconds in self._departures_by_service.get((route_id, stop_id, service_id), [])
+        ]
+        departures.sort()
+
+        if not departures:
+            return ScheduleStatus(
+                status=STATUS_NO_SERVICE_TODAY,
+                route_exists=True,
+                stop_exists=True,
+                route_serves_stop=True,
+                service_today=False,
+                service_expected_now=False,
+                next_scheduled_departure=None,
+            )
+
+        now_seconds = now.hour * 3600 + now.minute * 60 + now.second
+        next_departure_seconds = next((departure for departure in departures if departure >= now_seconds), None)
+        next_departure = (
+            dt.datetime.combine(now.date(), dt.time.min, tzinfo=now.tzinfo)
+            + dt.timedelta(seconds=next_departure_seconds)
+            if next_departure_seconds is not None
+            else None
+        )
+
+        active_lower_bound = now_seconds - int(self._active_window_before.total_seconds())
+        active_upper_bound = now_seconds + int(self._active_window_after.total_seconds())
+        service_expected_now = any(
+            active_lower_bound <= departure <= active_upper_bound for departure in departures
+        )
+
+        return ScheduleStatus(
+            status=STATUS_SERVICE_EXPECTED if service_expected_now else STATUS_NO_SERVICE_NOW,
+            route_exists=True,
+            stop_exists=True,
+            route_serves_stop=True,
+            service_today=True,
+            service_expected_now=service_expected_now,
+            next_scheduled_departure=next_departure,
+        )
+
+    def _ensure_loaded(self, now: dt.datetime) -> None:
+        if self._last_refresh and now - self._last_refresh < self._refresh_interval:
+            return
+
+        response = requests.get(self._schedule_url, headers=self._headers, timeout=30)
+        response.raise_for_status()
+        self._load_schedule_from_bytes(response.content)
+        self._last_refresh = now
+
+    def _load_schedule_from_bytes(self, archive_bytes: bytes) -> None:
+        self._route_ids.clear()
+        self._stop_ids.clear()
+        self._route_stop_service_ids.clear()
+        self._departures_by_service.clear()
+        self._calendar.clear()
+        self._calendar_exceptions.clear()
+
+        archive = zipfile.ZipFile(io.BytesIO(archive_bytes))
+
+        trip_to_route_service: dict[str, tuple[str, str]] = {}
+
+        with archive.open("routes.txt") as route_file:
+            for row in csv.DictReader(io.TextIOWrapper(route_file, "utf-8-sig")):
+                route_id = row["route_id"]
+                if route_id in self._monitored_routes:
+                    self._route_ids.add(route_id)
+
+        with archive.open("stops.txt") as stop_file:
+            for row in csv.DictReader(io.TextIOWrapper(stop_file, "utf-8-sig")):
+                stop_id = row["stop_id"]
+                if stop_id in self._monitored_stops:
+                    self._stop_ids.add(stop_id)
+
+        with archive.open("trips.txt") as trip_file:
+            for row in csv.DictReader(io.TextIOWrapper(trip_file, "utf-8-sig")):
+                route_id = row["route_id"]
+                if route_id not in self._monitored_routes:
+                    continue
+                trip_to_route_service[row["trip_id"]] = (route_id, row["service_id"])
+
+        with archive.open("stop_times.txt") as stop_time_file:
+            for row in csv.DictReader(io.TextIOWrapper(stop_time_file, "utf-8-sig")):
+                trip_id = row["trip_id"]
+                trip_details = trip_to_route_service.get(trip_id)
+                if trip_details is None:
+                    continue
+
+                stop_id = row["stop_id"]
+                if stop_id not in self._monitored_stops:
+                    continue
+
+                route_id, service_id = trip_details
+                departure_value = row["departure_time"] or row["arrival_time"]
+                if not departure_value:
+                    continue
+
+                departure_seconds = parse_gtfs_seconds(departure_value)
+                self._route_stop_service_ids[(route_id, stop_id)].add(service_id)
+                self._departures_by_service[(route_id, stop_id, service_id)].append(departure_seconds)
+
+        for departure_list in self._departures_by_service.values():
+            departure_list.sort()
+
+        with archive.open("calendar.txt") as calendar_file:
+            for row in csv.DictReader(io.TextIOWrapper(calendar_file, "utf-8-sig")):
+                weekdays = {
+                    index
+                    for index, column in enumerate(
+                        [
+                            "monday",
+                            "tuesday",
+                            "wednesday",
+                            "thursday",
+                            "friday",
+                            "saturday",
+                            "sunday",
+                        ]
+                    )
+                    if row[column] == "1"
+                }
+                self._calendar[row["service_id"]] = (
+                    weekdays,
+                    dt.datetime.strptime(row["start_date"], "%Y%m%d").date(),
+                    dt.datetime.strptime(row["end_date"], "%Y%m%d").date(),
+                )
+
+        with archive.open("calendar_dates.txt") as calendar_dates_file:
+            for row in csv.DictReader(io.TextIOWrapper(calendar_dates_file, "utf-8-sig")):
+                service_date = dt.datetime.strptime(row["date"], "%Y%m%d").date()
+                self._calendar_exceptions[service_date][row["service_id"]] = row["exception_type"] == "1"
+
+    def _active_service_ids(self, service_date: dt.date) -> set[str]:
+        active_ids = {
+            service_id
+            for service_id, (weekdays, start_date, end_date) in self._calendar.items()
+            if start_date <= service_date <= end_date and service_date.weekday() in weekdays
+        }
+
+        for service_id, enabled in self._calendar_exceptions.get(service_date, {}).items():
+            if enabled:
+                active_ids.add(service_id)
+            else:
+                active_ids.discard(service_id)
+
+        return active_ids

--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -4,7 +4,7 @@
     "documentation": "https://github.com/Jason-Morcos/ha-gtfs-rt",
     "dependencies": [],
     "codeowners": ["@Jason-Morcos"],
-    "version": "1.1.0",
+    "version": "1.2.0",
     "requirements": [
         "gtfs-realtime-bindings==1.0.0"
     ]

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -1,16 +1,18 @@
 import datetime
 import logging
-import requests
 import time
 from enum import Enum
 
+import requests
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME, CONF_UNIQUE_ID, UnitOfTime
-import homeassistant.util.dt as dt_util
 from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
+
+from .health import STATUS_LOOKUP_FAILED, STATUS_SERVICE_EXPECTED, StaticScheduleValidator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,38 +26,51 @@ ATTR_NEXT_UP = "Next bus"
 ATTR_NEXT_UP_DUE_IN = "Next bus due in"
 ATTR_NEXT_DELAYED_BY = "Next bus delayed by"
 ATTR_NEXT_OCCUPANCY = "Next bus occupancy"
+ATTR_SERVICE_STATUS = "Service status"
+ATTR_SERVICE_TODAY = "Service today"
+ATTR_SERVICE_EXPECTED_NOW = "Service expected now"
+ATTR_NEXT_SCHEDULED_DEPARTURE = "Next scheduled departure"
+ATTR_PROBLEM_REASON = "Problem reason"
 
-CONF_API_KEY = 'api_key'
-CONF_APIKEY = 'apikey'
-CONF_X_API_KEY = 'x_api_key'
+CONF_API_KEY = "api_key"
+CONF_APIKEY = "apikey"
+CONF_X_API_KEY = "x_api_key"
 CONF_HEADERS = "headers"
-CONF_STOP_ID = 'stopid'
-CONF_ROUTE = 'route'
-CONF_DEPARTURES = 'departures'
-CONF_TRIP_UPDATE_URL = 'trip_update_url'
-CONF_VEHICLE_POSITION_URL = 'vehicle_position_url'
+CONF_STOP_ID = "stopid"
+CONF_ROUTE = "route"
+CONF_DEPARTURES = "departures"
+CONF_TRIP_UPDATE_URL = "trip_update_url"
+CONF_VEHICLE_POSITION_URL = "vehicle_position_url"
+CONF_STATIC_SCHEDULE_URL = "static_schedule_url"
 
-DEFAULT_NAME = 'Next Bus'
-ICON = 'mdi:bus'
+DEFAULT_NAME = "Next Bus"
+ICON = "mdi:bus"
+REQUEST_TIMEOUT = 30
 
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=60)
 TIME_STR_FORMAT = "%H:%M"
 
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_TRIP_UPDATE_URL): cv.string,
-    vol.Exclusive(CONF_API_KEY, "headers"): cv.string,
-    vol.Exclusive(CONF_X_API_KEY, "headers"): cv.string,
-    vol.Exclusive(CONF_APIKEY, "headers"): cv.string,
-    vol.Exclusive(CONF_HEADERS, "headers"): {cv.string: cv.string},
-    vol.Optional(CONF_VEHICLE_POSITION_URL): cv.string,
-    vol.Optional(CONF_DEPARTURES): [{
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_UNIQUE_ID): cv.string,
-        vol.Required(CONF_STOP_ID): cv.string,
-        vol.Required(CONF_ROUTE): cv.string
-    }]
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_TRIP_UPDATE_URL): cv.string,
+        vol.Exclusive(CONF_API_KEY, "headers"): cv.string,
+        vol.Exclusive(CONF_X_API_KEY, "headers"): cv.string,
+        vol.Exclusive(CONF_APIKEY, "headers"): cv.string,
+        vol.Exclusive(CONF_HEADERS, "headers"): {cv.string: cv.string},
+        vol.Optional(CONF_VEHICLE_POSITION_URL): cv.string,
+        vol.Optional(CONF_STATIC_SCHEDULE_URL): cv.string,
+        vol.Optional(CONF_DEPARTURES): [
+            {
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(CONF_UNIQUE_ID): cv.string,
+                vol.Required(CONF_STOP_ID): cv.string,
+                vol.Required(CONF_ROUTE): cv.string,
+            }
+        ],
+    }
+)
+
 
 class OccupancyStatus(Enum):
     EMPTY = 0
@@ -68,6 +83,7 @@ class OccupancyStatus(Enum):
     NO_DATA_AVAILABLE = 7
     NOT_BOARDABLE = 8
 
+
 def due_in_minutes(timestamp):
     """Get the remaining minutes from now until a given datetime object."""
     diff = timestamp - dt_util.now().replace(tzinfo=None)
@@ -75,24 +91,37 @@ def due_in_minutes(timestamp):
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Get the Dublin public transport sensor."""
-    headers = config.get(CONF_HEADERS, {})
+    """Set up the legacy YAML sensor platform."""
+    headers = dict(config.get(CONF_HEADERS, {}))
     if (api_key := config.get(CONF_API_KEY)) is not None:
-        headers['Authorization'] = api_key
+        headers["Authorization"] = api_key
     elif (apikey := config.get(CONF_APIKEY)) is not None:
-        headers['apikey'] = apikey
+        headers["apikey"] = apikey
     elif (x_api_key := config.get(CONF_X_API_KEY)) is not None:
-        headers['x-api-key'] = x_api_key
-    data = PublicTransportData(config.get(CONF_TRIP_UPDATE_URL), config.get(CONF_VEHICLE_POSITION_URL), headers)
+        headers["x-api-key"] = x_api_key
+
+    monitored_departures = [
+        (departure.get(CONF_ROUTE), departure.get(CONF_STOP_ID))
+        for departure in config.get(CONF_DEPARTURES)
+    ]
+    data = PublicTransportData(
+        config.get(CONF_TRIP_UPDATE_URL),
+        config.get(CONF_VEHICLE_POSITION_URL),
+        headers,
+        monitored_departures,
+        config.get(CONF_STATIC_SCHEDULE_URL),
+    )
     sensors = []
     for departure in config.get(CONF_DEPARTURES):
-        sensors.append(PublicTransportSensor(
-            data,
-            departure.get(CONF_STOP_ID),
-            departure.get(CONF_ROUTE),
-            departure.get(CONF_NAME),
-            departure.get(CONF_UNIQUE_ID)
-        ))
+        sensors.append(
+            PublicTransportSensor(
+                data,
+                departure.get(CONF_STOP_ID),
+                departure.get(CONF_ROUTE),
+                departure.get(CONF_NAME),
+                departure.get(CONF_UNIQUE_ID),
+            )
+        )
 
     add_devices(sensors, True)
 
@@ -101,7 +130,6 @@ class PublicTransportSensor(SensorEntity):
     """Implementation of a public transport sensor."""
 
     def __init__(self, data, stop, route, name, unique_id):
-        """Initialize the sensor."""
         self.data = data
         self._stop = stop
         self._route = route
@@ -114,16 +142,50 @@ class PublicTransportSensor(SensorEntity):
     def _get_next_buses(self):
         return self.data.info.get(self._route, {}).get(self._stop, [])
 
+    def _get_schedule_status(self):
+        return self.data.get_schedule_status(self._route, self._stop)
+
+    def _get_problem_reason(self, schedule_status, next_buses):
+        if self.data.last_trip_update_error:
+            return self.data.last_trip_update_error
+        if schedule_status is None:
+            return None
+        if schedule_status.problem_reason:
+            return schedule_status.problem_reason
+        if schedule_status.status == STATUS_SERVICE_EXPECTED and len(next_buses) == 0:
+            next_departure = schedule_status.next_scheduled_departure
+            if next_departure is not None:
+                return (
+                    "Scheduled service is expected, but the realtime feed has no "
+                    f"matching departures before {next_departure.strftime(TIME_STR_FORMAT)}"
+                )
+            return "Scheduled service is expected, but the realtime feed has no matching departures"
+        return None
+
     @property
     def state(self):
-        """Return the state of the sensor."""
         next_buses = self._get_next_buses()
         return due_in_minutes(next_buses[0].arrival_time) if len(next_buses) > 0 else None
 
     @property
-    def extra_state_attributes(self):
-        """Return the state attributes."""
+    def available(self):
         next_buses = self._get_next_buses()
+        schedule_status = self._get_schedule_status()
+
+        if self.data.last_trip_update_error:
+            return False
+        if schedule_status is None or schedule_status.status == STATUS_LOOKUP_FAILED:
+            return True
+        if schedule_status.is_config_problem:
+            return False
+        if schedule_status.status == STATUS_SERVICE_EXPECTED and len(next_buses) == 0:
+            return False
+        return True
+
+    @property
+    def extra_state_attributes(self):
+        next_buses = self._get_next_buses()
+        schedule_status = self._get_schedule_status()
         attrs = {
             ATTR_DUE_IN: self.state,
             ATTR_DUE_AT: None,
@@ -136,44 +198,82 @@ class PublicTransportSensor(SensorEntity):
             ATTR_NEXT_DELAYED_BY: None,
             ATTR_NEXT_OCCUPANCY: None,
             ATTR_STOP_ID: self._stop,
-            ATTR_ROUTE: self._route
+            ATTR_ROUTE: self._route,
+            ATTR_SERVICE_STATUS: schedule_status.status if schedule_status else None,
+            ATTR_SERVICE_TODAY: schedule_status.service_today if schedule_status else None,
+            ATTR_SERVICE_EXPECTED_NOW: schedule_status.service_expected_now if schedule_status else None,
+            ATTR_NEXT_SCHEDULED_DEPARTURE: (
+                schedule_status.next_scheduled_departure.strftime(TIME_STR_FORMAT)
+                if schedule_status and schedule_status.next_scheduled_departure
+                else None
+            ),
+            ATTR_PROBLEM_REASON: self._get_problem_reason(schedule_status, next_buses),
         }
         if len(next_buses) > 0:
-            attrs[ATTR_DUE_AT] = next_buses[0].arrival_time.strftime(TIME_STR_FORMAT) if len(next_buses) > 0 else None
-            attrs[ATTR_OCCUPANCY] = next_buses[0].occupancy if len(next_buses) > 0 else None
-            attrs[ATTR_DELAYED_BY] = next_buses[0].delay / 60.0 if (len(next_buses) > 0 and next_buses[0].delay) else None
+            attrs[ATTR_DUE_AT] = next_buses[0].arrival_time.strftime(TIME_STR_FORMAT)
+            attrs[ATTR_OCCUPANCY] = next_buses[0].occupancy
+            attrs[ATTR_DELAYED_BY] = next_buses[0].delay / 60.0 if next_buses[0].delay else None
             if next_buses[0].position:
                 attrs[ATTR_LATITUDE] = next_buses[0].position.latitude
                 attrs[ATTR_LONGITUDE] = next_buses[0].position.longitude
         if len(next_buses) > 1:
-            attrs[ATTR_NEXT_UP] = next_buses[1].arrival_time.strftime(TIME_STR_FORMAT) if len(next_buses) > 1 else None
-            attrs[ATTR_NEXT_UP_DUE_IN] = due_in_minutes(next_buses[1].arrival_time) if len(next_buses) > 1 else None
-            attrs[ATTR_NEXT_OCCUPANCY] = next_buses[1].occupancy if len(next_buses) > 1 else None
-            attrs[ATTR_NEXT_DELAYED_BY] = next_buses[1].delay / 60.0 if (len(next_buses) > 1 and next_buses[1].delay) else None
+            attrs[ATTR_NEXT_UP] = next_buses[1].arrival_time.strftime(TIME_STR_FORMAT)
+            attrs[ATTR_NEXT_UP_DUE_IN] = due_in_minutes(next_buses[1].arrival_time)
+            attrs[ATTR_NEXT_OCCUPANCY] = next_buses[1].occupancy
+            attrs[ATTR_NEXT_DELAYED_BY] = next_buses[1].delay / 60.0 if next_buses[1].delay else None
         return attrs
 
     def update(self):
-        """Get the latest data from opendata.ch and update the states."""
         self.data.update()
 
 
-class PublicTransportData(object):
-    """The Class for handling the data retrieval."""
+class PublicTransportData:
+    """Handle realtime and optional static GTFS data retrieval."""
 
-    def __init__(self, trip_update_url, vehicle_position_url=None, headers=None):
-        """Initialize the info object."""
+    def __init__(
+        self,
+        trip_update_url,
+        vehicle_position_url=None,
+        headers=None,
+        monitored_departures=None,
+        static_schedule_url=None,
+    ):
         self._trip_update_url = trip_update_url
         self._vehicle_position_url = vehicle_position_url
-        self._headers = headers
+        self._headers = headers or {}
+        self._monitored_departures = monitored_departures or []
+        self._schedule_validator = (
+            StaticScheduleValidator(static_schedule_url, self._monitored_departures, self._headers)
+            if static_schedule_url
+            else None
+        )
         self.info = {}
+        self.last_trip_update_error = None
+        self._schedule_status = {}
+
+    def get_schedule_status(self, route_id, stop_id):
+        return self._schedule_status.get((route_id, stop_id))
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        positions, vehicles_trips, occupancy = self._get_vehicle_positions() if self._vehicle_position_url else [{}, {}, {}]
+        self.last_trip_update_error = None
+        self.info = {}
+
+        positions, vehicles_trips, occupancy = (
+            self._get_vehicle_positions() if self._vehicle_position_url else ({}, {}, {})
+        )
         self._update_route_statuses(positions, vehicles_trips, occupancy)
 
+        if self._schedule_validator:
+            now = dt_util.now()
+            self._schedule_status = {
+                (route_id, stop_id): self._schedule_validator.get_status(route_id, stop_id, now)
+                for route_id, stop_id in self._monitored_departures
+            }
+        else:
+            self._schedule_status = {}
+
     def _update_route_statuses(self, vehicle_positions, vehicles_trips, vehicle_occupancy):
-        """Get the latest data."""
         from google.transit import gtfs_realtime_pb2
 
         class StopDetails:
@@ -184,60 +284,73 @@ class PublicTransportData(object):
                 self.delay = delay
 
         feed = gtfs_realtime_pb2.FeedMessage()
-        response = requests.get(self._trip_update_url, headers=self._headers)
-        if response.status_code != 200:
-            _LOGGER.error("updating route status got {}:{}".format(response.status_code,response.content))
-        feed.ParseFromString(response.content)
+        try:
+            response = requests.get(self._trip_update_url, headers=self._headers, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            feed.ParseFromString(response.content)
+        except Exception as err:
+            self.last_trip_update_error = f"Realtime trip updates unavailable: {err}"
+            _LOGGER.error("Unable to refresh realtime trip updates: %s", err)
+            return
+
         departure_times = {}
-        
+
         for entity in feed.entity:
-            if entity.HasField('trip_update'):
-                route_id = entity.trip_update.trip.route_id
+            if not entity.HasField("trip_update"):
+                continue
 
-                # Get link between vehicle_id from trip_id from vehicles positions if needed
-                vehicle_id = entity.trip_update.vehicle.id
-                if not vehicle_id:
-                    vehicle_id = vehicles_trips.get(entity.trip_update.trip.trip_id)
+            route_id = entity.trip_update.trip.route_id
+            vehicle_id = entity.trip_update.vehicle.id
+            if not vehicle_id:
+                vehicle_id = vehicles_trips.get(entity.trip_update.trip.trip_id)
 
-                if route_id not in departure_times:
-                    departure_times[route_id] = {}
-                for stop in entity.trip_update.stop_time_update:
-                    stop_id = stop.stop_id
-                    if not departure_times[route_id].get(stop_id):
-                        departure_times[route_id][stop_id] = []
-                    # Keep only future arrival.time (gtfs data can give past arrival.time, which is useless and show negative time as result)
-                    if int(stop.departure.time) > int(time.time()):
-                        # Use stop departure time; fall back on stop arrival time if not available
-                        details = StopDetails(
-                            datetime.datetime.fromtimestamp(stop.departure.time),
-                            vehicle_positions.get(vehicle_id),
-                            vehicle_occupancy.get(vehicle_id),
-                            stop.departure.delay
-                        )
-                        departure_times[route_id][stop_id].append(details)
-                    elif int(stop.arrival.time) > int(time.time()):
-                        details = StopDetails(
-                            datetime.datetime.fromtimestamp(stop.arrival.time),
-                            vehicle_positions.get(vehicle_id),
-                            vehicle_occupancy.get(vehicle_id),
-                            stop.arrival.delay
-                        )
-                        departure_times[route_id][stop_id].append(details)
+            if route_id not in departure_times:
+                departure_times[route_id] = {}
 
-        # Sort by arrival time
+            for stop in entity.trip_update.stop_time_update:
+                stop_id = stop.stop_id
+                if not departure_times[route_id].get(stop_id):
+                    departure_times[route_id][stop_id] = []
+
+                if int(stop.departure.time) > int(time.time()):
+                    details = StopDetails(
+                        datetime.datetime.fromtimestamp(stop.departure.time),
+                        vehicle_positions.get(vehicle_id),
+                        vehicle_occupancy.get(vehicle_id),
+                        stop.departure.delay,
+                    )
+                    departure_times[route_id][stop_id].append(details)
+                elif int(stop.arrival.time) > int(time.time()):
+                    details = StopDetails(
+                        datetime.datetime.fromtimestamp(stop.arrival.time),
+                        vehicle_positions.get(vehicle_id),
+                        vehicle_occupancy.get(vehicle_id),
+                        stop.arrival.delay,
+                    )
+                    departure_times[route_id][stop_id].append(details)
+
         for route in departure_times:
             for stop in departure_times[route]:
-                departure_times[route][stop].sort(key=lambda t: t.arrival_time)
+                departure_times[route][stop].sort(key=lambda item: item.arrival_time)
 
         self.info = departure_times
 
     def _get_vehicle_positions(self):
         from google.transit import gtfs_realtime_pb2
+
         feed = gtfs_realtime_pb2.FeedMessage()
-        response = requests.get(self._vehicle_position_url, headers=self._headers)
-        if response.status_code != 200:
-            _LOGGER.error("updating vehicle positions got {}:{}.".format(response.status_code, response.content))
-        feed.ParseFromString(response.content)
+        try:
+            response = requests.get(
+                self._vehicle_position_url,
+                headers=self._headers,
+                timeout=REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            feed.ParseFromString(response.content)
+        except Exception as err:
+            _LOGGER.warning("Unable to refresh vehicle positions: %s", err)
+            return {}, {}, {}
+
         positions = {}
         vehicles_trips = {}
         occupancy = {}
@@ -245,9 +358,9 @@ class PublicTransportData(object):
         for entity in feed.entity:
             vehicle = entity.vehicle
             if not vehicle.trip.route_id:
-                # Vehicle is not in service
                 continue
             positions[vehicle.vehicle.id] = vehicle.position
             vehicles_trips[vehicle.trip.trip_id] = vehicle.vehicle.id
             occupancy[vehicle.vehicle.id] = OccupancyStatus(vehicle.occupancy_status).name
+
         return positions, vehicles_trips, occupancy

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,111 @@
+import datetime as dt
+import io
+import sys
+import unittest
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from custom_components.gtfs_rt.health import (  # noqa: E402
+    STATUS_INVALID_STOP,
+    STATUS_NO_SERVICE_NOW,
+    STATUS_NO_SERVICE_TODAY,
+    STATUS_ROUTE_STOP_MISMATCH,
+    STATUS_SERVICE_EXPECTED,
+    StaticScheduleValidator,
+)
+
+
+def build_archive(files):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+class StaticScheduleValidatorTests(unittest.TestCase):
+    def setUp(self):
+        archive = build_archive(
+            {
+                "routes.txt": (
+                    "route_id,agency_id,route_short_name,route_long_name,route_desc,route_type\n"
+                    "100214,1,372,,,3\n"
+                ),
+                "stops.txt": (
+                    "stop_id,stop_name,stop_lat,stop_lon\n"
+                    "23895,25th Ave NE & NE 75th St (SB),0,0\n"
+                    "25797,25th Ave NE & NE 75th St (NB),0,0\n"
+                ),
+                "trips.txt": (
+                    "route_id,service_id,trip_id,trip_headsign,direction_id,shape_id\n"
+                    "100214,weekday,trip_one,U-District Station,1,shape\n"
+                ),
+                "stop_times.txt": (
+                    "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n"
+                    "trip_one,14:30:00,14:30:00,23895,1\n"
+                    "trip_one,15:15:00,15:15:00,23895,2\n"
+                ),
+                "calendar.txt": (
+                    "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n"
+                    "weekday,1,1,1,1,1,0,0,20260101,20261231\n"
+                ),
+                "calendar_dates.txt": "service_id,date,exception_type\n",
+            }
+        )
+
+        self.validator = StaticScheduleValidator(
+            "https://example.com/google_transit.zip",
+            [("100214", "23895"), ("100214", "25797"), ("100214", "99999")],
+            refresh_interval=dt.timedelta(days=365),
+        )
+        self.validator._load_schedule_from_bytes(archive)
+        self.validator._last_refresh = dt.datetime(2026, 4, 3, 14, 0, tzinfo=dt.timezone.utc)
+
+    def test_service_expected_when_departure_is_imminent(self):
+        now = dt.datetime(2026, 4, 3, 14, 0, tzinfo=dt.timezone.utc)
+        status = self.validator.get_status("100214", "23895", now)
+
+        self.assertEqual(status.status, STATUS_SERVICE_EXPECTED)
+        self.assertTrue(status.service_today)
+        self.assertTrue(status.service_expected_now)
+        self.assertEqual(status.next_scheduled_departure.hour, 14)
+        self.assertEqual(status.next_scheduled_departure.minute, 30)
+
+    def test_no_service_now_when_next_trip_is_outside_window(self):
+        now = dt.datetime(2026, 4, 3, 12, 0, tzinfo=dt.timezone.utc)
+        status = self.validator.get_status("100214", "23895", now)
+
+        self.assertEqual(status.status, STATUS_NO_SERVICE_NOW)
+        self.assertTrue(status.service_today)
+        self.assertFalse(status.service_expected_now)
+
+    def test_no_service_today_on_weekend(self):
+        now = dt.datetime(2026, 4, 4, 14, 0, tzinfo=dt.timezone.utc)
+        status = self.validator.get_status("100214", "23895", now)
+
+        self.assertEqual(status.status, STATUS_NO_SERVICE_TODAY)
+        self.assertFalse(status.service_today)
+        self.assertFalse(status.service_expected_now)
+
+    def test_invalid_stop(self):
+        now = dt.datetime(2026, 4, 3, 14, 0, tzinfo=dt.timezone.utc)
+        status = self.validator.get_status("100214", "99999", now)
+
+        self.assertEqual(status.status, STATUS_INVALID_STOP)
+        self.assertTrue(status.route_exists)
+        self.assertFalse(status.stop_exists)
+
+    def test_route_stop_mismatch(self):
+        now = dt.datetime(2026, 4, 3, 14, 0, tzinfo=dt.timezone.utc)
+        status = self.validator.get_status("100214", "25797", now)
+
+        self.assertEqual(status.status, STATUS_ROUTE_STOP_MISMATCH)
+        self.assertTrue(status.route_exists)
+        self.assertTrue(status.stop_exists)
+        self.assertFalse(status.route_serves_stop)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional `static_schedule_url` support so GTFS sensors can distinguish no-service windows from actual route/stop/feed problems
- mark sensors unavailable when the static feed says the route/stop is invalid or when service should exist but realtime has no matching departures
- expose schedule-health attributes and add focused tests for the static GTFS validator

## Notes
- this branch intentionally does not implement route devices yet
- Home Assistant route-device grouping will require a config-entry-backed refactor because device registration is tied to config-entry entities

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall custom_components`
- validated the static schedule classifier against the live King County static GTFS feed for routes 372 and 79
