### PR TITLE
Add route devices via GTFS config entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ local transit systems that provide gtfs feeds.
 
 ## Installation (HACS) - Recommended
 0. Have [HACS](https://custom-components.github.io/hacs/installation/manual/) installed, this will allow you to easily update
-1. Add `https://github.com/zacs/ha-gtfs-rt` as a [custom repository](https://custom-components.github.io/hacs/usage/settings/#add-custom-repositories) as Type: Integration
+1. Add `https://github.com/Jason-Morcos/ha-gtfs-rt` as a [custom repository](https://custom-components.github.io/hacs/usage/settings/#add-custom-repositories) as Type: Integration
 2. Click install under "GTFS-Realtime", restart your instance.
 
 ## Installation (Manual)
@@ -22,29 +22,33 @@ Add the following to your `configuration.yaml` file:
 ```yaml
 # Example entry for Austin TX
 
-sensor:
-  - platform: gtfs_rt
+gtfs_rt:
+  - name: Austin Metro
+    entity_namespace: gtfs_austin
     trip_update_url: 'https://data.texas.gov/download/rmk2-acnw/application%2foctet-stream'
     vehicle_position_url: 'https://data.texas.gov/download/eiei-9rpf/application%2Foctet-stream'
+    static_schedule_url: 'https://example.com/google_transit.zip'
     departures:
-    - name: Downtown to airport
-      unique_id: 3f2f8b2e-8ed2-4d7c-b2a6-9a8f0911b7a9
-      route: 100
-      stopid: 514
+      - name: Downtown to airport
+        unique_id: 3f2f8b2e-8ed2-4d7c-b2a6-9a8f0911b7a9
+        route: 100
+        stopid: 514
 ```
 
 ```yaml
 # Example entry for Seattle WA
 
-- platform: gtfs_rt
-  trip_update_url: 'http://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/1.pb?key=TEST'
-  vehicle_position_url: 'http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/1.pb?key=TEST'
-  static_schedule_url: 'https://metro.kingcounty.gov/gtfs/google_transit.zip'
-  departures:
-  - name: "48 to Uni"
-    unique_id: 8af3e2dd-9f0a-4b84-8ec0-109c9d2a7c4f
-    route: 100228
-    stopid: 36800
+gtfs_rt:
+  - name: King County Metro
+    entity_namespace: gtfs_kingcountymetro
+    trip_update_url: 'http://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/1.pb?key=TEST'
+    vehicle_position_url: 'http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/1.pb?key=TEST'
+    static_schedule_url: 'https://metro.kingcounty.gov/gtfs/google_transit.zip'
+    departures:
+      - name: "48 to Uni"
+        unique_id: 8af3e2dd-9f0a-4b84-8ec0-109c9d2a7c4f
+        route: 100228
+        stopid: 36800
 ```
 
 ```yaml
@@ -89,6 +93,8 @@ sensor:
 
 Configuration variables:
 
+- **name** (*Optional*): Friendly title for the GTFS feed. Used for the config-entry title and as a prefix for route devices.
+- **entity_namespace** (*Optional*): Stable namespace used as the feed identifier during YAML import. Reusing the same value lets existing entities keep their entity IDs after migration.
 - **trip_update_url** (*Required*): Provides bus route etas. See the **Finding Feeds** section at the bottom of the page for more details on how to find these
 - **vehicle_position_url** (*Optional*): Provides live bus position tracking on the home assistant map
 - **static_schedule_url** (*Optional*): A static GTFS ZIP feed used to validate whether a stop is valid and whether service should currently exist. When configured, the entity stays `unknown` during normal no-service windows, but becomes `unavailable` when the route/stop is invalid or scheduled service should exist and the realtime feed has no matching departures.
@@ -105,6 +111,10 @@ When `static_schedule_url` is configured, each sensor also adds:
 - `Service expected now`
 - `Next scheduled departure`
 - `Problem reason`
+
+When the feed is configured under the top-level `gtfs_rt:` key, the integration imports it into a Home Assistant config entry. That allows each route to appear as its own service device, so a line like `372` can group all of your chosen stops under a single device.
+
+The legacy `sensor: - platform: gtfs_rt` format still works, but it will not create route devices and is now considered deprecated.
 
 ## Screenshot
 

--- a/custom_components/gtfs_rt/__init__.py
+++ b/custom_components/gtfs_rt/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import Platform
+
+from .config import FEED_CONFIG_SCHEMA, normalize_feed_config
+from .const import DOMAIN
+
+PLATFORMS = [Platform.SENSOR]
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.All(cv.ensure_list, [vol.Schema(FEED_CONFIG_SCHEMA)]),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+    """Import YAML feed definitions into config entries."""
+    hass.data.setdefault(DOMAIN, {})
+
+    for raw_feed in config.get(DOMAIN, []):
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": "import"},
+                data=normalize_feed_config(dict(raw_feed)),
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up GTFS-Realtime from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a GTFS-Realtime config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    return unload_ok

--- a/custom_components/gtfs_rt/config.py
+++ b/custom_components/gtfs_rt/config.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from urllib.parse import urlparse
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_NAME, CONF_UNIQUE_ID
+
+from .const import (
+    CONF_API_KEY,
+    CONF_APIKEY,
+    CONF_DEPARTURES,
+    CONF_ENTITY_NAMESPACE,
+    CONF_FEED_ID,
+    CONF_HEADERS,
+    CONF_ROUTE,
+    CONF_STATIC_SCHEDULE_URL,
+    CONF_STOP_ID,
+    CONF_TRIP_UPDATE_URL,
+    CONF_VEHICLE_POSITION_URL,
+    CONF_X_API_KEY,
+    DEFAULT_NAME,
+    DEFAULT_TITLE,
+)
+
+DEPARTURE_SCHEMA = {
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_UNIQUE_ID): cv.string,
+    vol.Required(CONF_STOP_ID): cv.string,
+    vol.Required(CONF_ROUTE): cv.string,
+}
+
+FEED_CONFIG_SCHEMA = {
+    vol.Optional(CONF_NAME, default=DEFAULT_TITLE): cv.string,
+    vol.Optional(CONF_ENTITY_NAMESPACE): cv.string,
+    vol.Required(CONF_TRIP_UPDATE_URL): cv.string,
+    vol.Exclusive(CONF_API_KEY, "headers"): cv.string,
+    vol.Exclusive(CONF_X_API_KEY, "headers"): cv.string,
+    vol.Exclusive(CONF_APIKEY, "headers"): cv.string,
+    vol.Exclusive(CONF_HEADERS, "headers"): {cv.string: cv.string},
+    vol.Optional(CONF_VEHICLE_POSITION_URL): cv.string,
+    vol.Optional(CONF_STATIC_SCHEDULE_URL): cv.string,
+    vol.Required(CONF_DEPARTURES): [DEPARTURE_SCHEMA],
+}
+
+
+def build_headers(config: dict) -> dict[str, str]:
+    """Build the outbound HTTP headers for a GTFS feed definition."""
+    headers = dict(config.get(CONF_HEADERS, {}))
+    if (api_key := config.get(CONF_API_KEY)) is not None:
+        headers["Authorization"] = api_key
+    elif (apikey := config.get(CONF_APIKEY)) is not None:
+        headers["apikey"] = apikey
+    elif (x_api_key := config.get(CONF_X_API_KEY)) is not None:
+        headers["x-api-key"] = x_api_key
+    return headers
+
+
+def derive_feed_id(config: dict) -> str:
+    """Return a stable feed identifier for config-entry and device grouping."""
+    if namespace := config.get(CONF_ENTITY_NAMESPACE):
+        return namespace
+
+    payload = {
+        CONF_TRIP_UPDATE_URL: config.get(CONF_TRIP_UPDATE_URL),
+        CONF_VEHICLE_POSITION_URL: config.get(CONF_VEHICLE_POSITION_URL),
+        CONF_STATIC_SCHEDULE_URL: config.get(CONF_STATIC_SCHEDULE_URL),
+        CONF_HEADERS: config.get(CONF_HEADERS, {}),
+    }
+    digest = hashlib.sha1(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"feed_{digest}"
+
+
+def derive_feed_title(config: dict) -> str:
+    """Build a human-friendly title for the config entry."""
+    if name := config.get(CONF_NAME):
+        return name
+    if namespace := config.get(CONF_ENTITY_NAMESPACE):
+        return namespace
+    parsed = urlparse(config[CONF_TRIP_UPDATE_URL])
+    if parsed.netloc:
+        return parsed.netloc
+    return DEFAULT_TITLE
+
+
+def derive_departure_unique_id(feed_id: str, departure: dict) -> str:
+    """Generate a stable entity unique_id when the user has not set one."""
+    payload = {
+        CONF_NAME: departure.get(CONF_NAME, DEFAULT_NAME),
+        CONF_ROUTE: departure[CONF_ROUTE],
+        CONF_STOP_ID: departure[CONF_STOP_ID],
+        CONF_FEED_ID: feed_id,
+    }
+    return hashlib.sha1(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def normalize_feed_config(config: dict) -> dict:
+    """Normalize YAML or config-flow input into stored config-entry data."""
+    headers = build_headers(config)
+    feed_id = config.get(CONF_FEED_ID) or derive_feed_id({**config, CONF_HEADERS: headers})
+
+    departures = []
+    for departure in config[CONF_DEPARTURES]:
+        departure_dict = {
+            CONF_NAME: departure.get(CONF_NAME, DEFAULT_NAME),
+            CONF_ROUTE: str(departure[CONF_ROUTE]),
+            CONF_STOP_ID: str(departure[CONF_STOP_ID]),
+        }
+        departure_dict[CONF_UNIQUE_ID] = str(
+            departure.get(CONF_UNIQUE_ID) or derive_departure_unique_id(feed_id, departure_dict)
+        )
+        departures.append(departure_dict)
+
+    normalized = {
+        CONF_FEED_ID: feed_id,
+        CONF_NAME: derive_feed_title(config),
+        CONF_TRIP_UPDATE_URL: config[CONF_TRIP_UPDATE_URL],
+        CONF_DEPARTURES: departures,
+    }
+    if headers:
+        normalized[CONF_HEADERS] = headers
+    if vehicle_position_url := config.get(CONF_VEHICLE_POSITION_URL):
+        normalized[CONF_VEHICLE_POSITION_URL] = vehicle_position_url
+    if static_schedule_url := config.get(CONF_STATIC_SCHEDULE_URL):
+        normalized[CONF_STATIC_SCHEDULE_URL] = static_schedule_url
+    if entity_namespace := config.get(CONF_ENTITY_NAMESPACE):
+        normalized[CONF_ENTITY_NAMESPACE] = entity_namespace
+    return normalized

--- a/custom_components/gtfs_rt/config_flow.py
+++ b/custom_components/gtfs_rt/config_flow.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_NAME
+
+from .config import normalize_feed_config
+from .const import CONF_FEED_ID, DOMAIN
+
+
+class GTFSRtConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Manage GTFS-Realtime config entries created from YAML imports."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """The integration currently relies on YAML-backed imports."""
+        return self.async_abort(reason="yaml_only")
+
+    async def async_step_import(self, import_data):
+        """Create or update a config entry from YAML configuration."""
+        data = normalize_feed_config(import_data)
+        feed_id = data[CONF_FEED_ID]
+
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.data.get(CONF_FEED_ID) != feed_id:
+                continue
+            if entry.data != data or entry.title != data[CONF_NAME]:
+                self.hass.config_entries.async_update_entry(entry, data=data, title=data[CONF_NAME])
+                await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="already_configured")
+
+        return self.async_create_entry(title=data[CONF_NAME], data=data)

--- a/custom_components/gtfs_rt/const.py
+++ b/custom_components/gtfs_rt/const.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+CONF_API_KEY = "api_key"
+CONF_APIKEY = "apikey"
+CONF_DEPARTURES = "departures"
+CONF_ENTITY_NAMESPACE = "entity_namespace"
+CONF_FEED_ID = "feed_id"
+CONF_HEADERS = "headers"
+CONF_ROUTE = "route"
+CONF_STATIC_SCHEDULE_URL = "static_schedule_url"
+CONF_STOP_ID = "stopid"
+CONF_TRIP_UPDATE_URL = "trip_update_url"
+CONF_VEHICLE_POSITION_URL = "vehicle_position_url"
+CONF_X_API_KEY = "x_api_key"
+
+DEFAULT_NAME = "Next Bus"
+DEFAULT_TITLE = "GTFS-Realtime"
+DOMAIN = "gtfs_rt"
+ICON = "mdi:bus"
+REQUEST_TIMEOUT = 30
+TIME_STR_FORMAT = "%H:%M"

--- a/custom_components/gtfs_rt/health.py
+++ b/custom_components/gtfs_rt/health.py
@@ -74,6 +74,7 @@ class StaticScheduleValidator:
         self._last_refresh: dt.datetime | None = None
         self._route_ids: set[str] = set()
         self._stop_ids: set[str] = set()
+        self._route_labels: dict[str, str] = {}
         self._route_stop_service_ids: dict[tuple[str, str], set[str]] = defaultdict(set)
         self._departures_by_service: dict[tuple[str, str, str], list[int]] = defaultdict(list)
         self._calendar: dict[str, tuple[set[int], dt.date, dt.date]] = {}
@@ -178,7 +179,11 @@ class StaticScheduleValidator:
             service_today=True,
             service_expected_now=service_expected_now,
             next_scheduled_departure=next_departure,
-        )
+            )
+
+    def get_route_label(self, route_id: str) -> str | None:
+        """Return a human-friendly route label when the static feed provides one."""
+        return self._route_labels.get(route_id)
 
     def _ensure_loaded(self, now: dt.datetime) -> None:
         if self._last_refresh and now - self._last_refresh < self._refresh_interval:
@@ -192,6 +197,7 @@ class StaticScheduleValidator:
     def _load_schedule_from_bytes(self, archive_bytes: bytes) -> None:
         self._route_ids.clear()
         self._stop_ids.clear()
+        self._route_labels.clear()
         self._route_stop_service_ids.clear()
         self._departures_by_service.clear()
         self._calendar.clear()
@@ -206,6 +212,11 @@ class StaticScheduleValidator:
                 route_id = row["route_id"]
                 if route_id in self._monitored_routes:
                     self._route_ids.add(route_id)
+                    self._route_labels[route_id] = (
+                        row.get("route_short_name")
+                        or row.get("route_long_name")
+                        or route_id
+                    )
 
         with archive.open("stops.txt") as stop_file:
             for row in csv.DictReader(io.TextIOWrapper(stop_file, "utf-8-sig")):

--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -4,7 +4,8 @@
     "documentation": "https://github.com/Jason-Morcos/ha-gtfs-rt",
     "dependencies": [],
     "codeowners": ["@Jason-Morcos"],
-    "version": "1.2.0",
+    "config_flow": true,
+    "version": "1.3.0",
     "requirements": [
         "gtfs-realtime-bindings==1.0.0"
     ]

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -1,17 +1,35 @@
+from __future__ import annotations
+
 import datetime
 import logging
 import time
 from enum import Enum
 
 import requests
-import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME, CONF_UNIQUE_ID, UnitOfTime
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import Throttle
 
+from .config import FEED_CONFIG_SCHEMA, normalize_feed_config
+from .const import (
+    CONF_DEPARTURES,
+    CONF_FEED_ID,
+    CONF_HEADERS,
+    CONF_ROUTE,
+    CONF_STATIC_SCHEDULE_URL,
+    CONF_STOP_ID,
+    CONF_TRIP_UPDATE_URL,
+    CONF_VEHICLE_POSITION_URL,
+    DEFAULT_NAME,
+    DOMAIN,
+    ICON,
+    REQUEST_TIMEOUT,
+    TIME_STR_FORMAT,
+)
 from .health import STATUS_LOOKUP_FAILED, STATUS_SERVICE_EXPECTED, StaticScheduleValidator
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,44 +50,10 @@ ATTR_SERVICE_EXPECTED_NOW = "Service expected now"
 ATTR_NEXT_SCHEDULED_DEPARTURE = "Next scheduled departure"
 ATTR_PROBLEM_REASON = "Problem reason"
 
-CONF_API_KEY = "api_key"
-CONF_APIKEY = "apikey"
-CONF_X_API_KEY = "x_api_key"
-CONF_HEADERS = "headers"
-CONF_STOP_ID = "stopid"
-CONF_ROUTE = "route"
-CONF_DEPARTURES = "departures"
-CONF_TRIP_UPDATE_URL = "trip_update_url"
-CONF_VEHICLE_POSITION_URL = "vehicle_position_url"
-CONF_STATIC_SCHEDULE_URL = "static_schedule_url"
-
-DEFAULT_NAME = "Next Bus"
-ICON = "mdi:bus"
-REQUEST_TIMEOUT = 30
-
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=60)
-TIME_STR_FORMAT = "%H:%M"
 
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_TRIP_UPDATE_URL): cv.string,
-        vol.Exclusive(CONF_API_KEY, "headers"): cv.string,
-        vol.Exclusive(CONF_X_API_KEY, "headers"): cv.string,
-        vol.Exclusive(CONF_APIKEY, "headers"): cv.string,
-        vol.Exclusive(CONF_HEADERS, "headers"): {cv.string: cv.string},
-        vol.Optional(CONF_VEHICLE_POSITION_URL): cv.string,
-        vol.Optional(CONF_STATIC_SCHEDULE_URL): cv.string,
-        vol.Optional(CONF_DEPARTURES): [
-            {
-                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-                vol.Optional(CONF_UNIQUE_ID): cv.string,
-                vol.Required(CONF_STOP_ID): cv.string,
-                vol.Required(CONF_ROUTE): cv.string,
-            }
-        ],
-    }
-)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(FEED_CONFIG_SCHEMA)
 
 
 class OccupancyStatus(Enum):
@@ -90,49 +74,76 @@ def due_in_minutes(timestamp):
     return int(diff.total_seconds() / 60)
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the legacy YAML sensor platform."""
-    headers = dict(config.get(CONF_HEADERS, {}))
-    if (api_key := config.get(CONF_API_KEY)) is not None:
-        headers["Authorization"] = api_key
-    elif (apikey := config.get(CONF_APIKEY)) is not None:
-        headers["apikey"] = apikey
-    elif (x_api_key := config.get(CONF_X_API_KEY)) is not None:
-        headers["x-api-key"] = x_api_key
-
+def _build_shared_data(config):
     monitored_departures = [
-        (departure.get(CONF_ROUTE), departure.get(CONF_STOP_ID))
-        for departure in config.get(CONF_DEPARTURES)
+        (departure[CONF_ROUTE], departure[CONF_STOP_ID])
+        for departure in config[CONF_DEPARTURES]
     ]
-    data = PublicTransportData(
-        config.get(CONF_TRIP_UPDATE_URL),
+    return PublicTransportData(
+        config[CONF_TRIP_UPDATE_URL],
         config.get(CONF_VEHICLE_POSITION_URL),
-        headers,
+        config.get(CONF_HEADERS, {}),
         monitored_departures,
         config.get(CONF_STATIC_SCHEDULE_URL),
     )
-    sensors = []
-    for departure in config.get(CONF_DEPARTURES):
-        sensors.append(
-            PublicTransportSensor(
-                data,
-                departure.get(CONF_STOP_ID),
-                departure.get(CONF_ROUTE),
-                departure.get(CONF_NAME),
-                departure.get(CONF_UNIQUE_ID),
-            )
-        )
 
-    add_devices(sensors, True)
+
+def _build_sensors(data, config, config_entry=None):
+    return [
+        PublicTransportSensor(
+            data=data,
+            stop=departure[CONF_STOP_ID],
+            route=departure[CONF_ROUTE],
+            name=departure.get(CONF_NAME, DEFAULT_NAME),
+            unique_id=departure.get(CONF_UNIQUE_ID),
+            feed_id=config.get(CONF_FEED_ID),
+            feed_name=config.get(CONF_NAME),
+            config_entry_id=config_entry.entry_id if config_entry else None,
+        )
+        for departure in config[CONF_DEPARTURES]
+    ]
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the legacy YAML sensor platform."""
+    normalized = normalize_feed_config(dict(config))
+    already_imported = any(
+        entry.data.get(CONF_FEED_ID) == normalized[CONF_FEED_ID]
+        for entry in hass.config_entries.async_entries(DOMAIN)
+    )
+    if already_imported:
+        _LOGGER.debug(
+            "Skipping legacy platform setup for %s because a config entry already exists",
+            normalized.get(CONF_NAME, DEFAULT_NAME),
+        )
+        return
+
+    _LOGGER.warning(
+        "Legacy sensor platform configuration for gtfs_rt is deprecated. "
+        "Move the feed under the top-level gtfs_rt section to enable route devices."
+    )
+    data = _build_shared_data(normalized)
+    add_devices(_build_sensors(data, normalized), True)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up GTFS-Realtime sensors from a config entry."""
+    config = dict(config_entry.data)
+    data = _build_shared_data(config)
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = data
+    async_add_entities(_build_sensors(data, config, config_entry), True)
 
 
 class PublicTransportSensor(SensorEntity):
     """Implementation of a public transport sensor."""
 
-    def __init__(self, data, stop, route, name, unique_id):
+    def __init__(self, data, stop, route, name, unique_id, feed_id=None, feed_name=None, config_entry_id=None):
         self.data = data
         self._stop = stop
         self._route = route
+        self._feed_id = feed_id
+        self._feed_name = feed_name
+        self._config_entry_id = config_entry_id
 
         self._attr_name = name
         self._attr_icon = ICON
@@ -161,6 +172,21 @@ class PublicTransportSensor(SensorEntity):
                 )
             return "Scheduled service is expected, but the realtime feed has no matching departures"
         return None
+
+    @property
+    def device_info(self):
+        if not self._feed_id or not self._config_entry_id:
+            return None
+
+        route_label = self.data.get_route_label(self._route) or self._route
+        feed_prefix = f"{self._feed_name} " if self._feed_name else ""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._feed_id}:route:{self._route}")},
+            name=f"{feed_prefix}Route {route_label}",
+            entry_type=DeviceEntryType.SERVICE,
+            manufacturer="GTFS-Realtime",
+            model="Transit Route",
+        )
 
     @property
     def state(self):
@@ -253,6 +279,11 @@ class PublicTransportData:
 
     def get_schedule_status(self, route_id, stop_id):
         return self._schedule_status.get((route_id, stop_id))
+
+    def get_route_label(self, route_id):
+        if not self._schedule_validator:
+            return None
+        return self._schedule_validator.get_route_label(route_id)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/custom_components/gtfs_rt/strings.json
+++ b/custom_components/gtfs_rt/strings.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "This GTFS feed is already configured.",
+      "yaml_only": "This integration is configured from YAML via the gtfs_rt section."
+    }
+  }
+}

--- a/custom_components/gtfs_rt/translations/en.json
+++ b/custom_components/gtfs_rt/translations/en.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "This GTFS feed is already configured.",
+      "yaml_only": "This integration is configured from YAML via the gtfs_rt section."
+    }
+  }
+}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,20 +1,27 @@
 import datetime as dt
+import importlib.util
 import io
 import sys
+import types
 import unittest
 import zipfile
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+ROOT = Path(__file__).resolve().parents[1]
+HEALTH_PATH = ROOT / "custom_components" / "gtfs_rt" / "health.py"
+SPEC = importlib.util.spec_from_file_location("gtfs_rt_health", HEALTH_PATH)
+HEALTH = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules.setdefault("requests", types.SimpleNamespace(get=None))
+sys.modules[SPEC.name] = HEALTH
+SPEC.loader.exec_module(HEALTH)
 
-from custom_components.gtfs_rt.health import (  # noqa: E402
-    STATUS_INVALID_STOP,
-    STATUS_NO_SERVICE_NOW,
-    STATUS_NO_SERVICE_TODAY,
-    STATUS_ROUTE_STOP_MISMATCH,
-    STATUS_SERVICE_EXPECTED,
-    StaticScheduleValidator,
-)
+STATUS_INVALID_STOP = HEALTH.STATUS_INVALID_STOP
+STATUS_NO_SERVICE_NOW = HEALTH.STATUS_NO_SERVICE_NOW
+STATUS_NO_SERVICE_TODAY = HEALTH.STATUS_NO_SERVICE_TODAY
+STATUS_ROUTE_STOP_MISMATCH = HEALTH.STATUS_ROUTE_STOP_MISMATCH
+STATUS_SERVICE_EXPECTED = HEALTH.STATUS_SERVICE_EXPECTED
+StaticScheduleValidator = HEALTH.StaticScheduleValidator
 
 
 def build_archive(files):
@@ -105,6 +112,12 @@ class StaticScheduleValidatorTests(unittest.TestCase):
         self.assertTrue(status.route_exists)
         self.assertTrue(status.stop_exists)
         self.assertFalse(status.route_serves_stop)
+
+    def test_route_label_comes_from_static_feed(self):
+        now = dt.datetime(2026, 4, 3, 14, 0, tzinfo=dt.timezone.utc)
+        self.validator.get_status("100214", "23895", now)
+
+        self.assertEqual(self.validator.get_route_label("100214"), "372")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- move GTFS feed setup to a top-level `gtfs_rt:` YAML block that imports into a config entry
- create one Home Assistant service device per route so selected stop sensors group under lines like `372` and `79`
- keep the schedule-aware health logic from the previous merge and update the README/tests for the new configuration model

## Notes
- this keeps a legacy `sensor: - platform: gtfs_rt` fallback for older installs, but route devices require the new `gtfs_rt:` config-entry import path
- the companion Home Assistant config change updates `packages/transit_api.yaml` to the new format and should be deployed alongside this package update

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall custom_components tests`
