### PR TITLE
Keep missing realtime GTFS stops as unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Configuration variables:
 - **entity_namespace** (*Optional*): Stable namespace used as the feed identifier during YAML import. Reusing the same value lets existing entities keep their entity IDs after migration.
 - **trip_update_url** (*Required*): Provides bus route etas. See the **Finding Feeds** section at the bottom of the page for more details on how to find these
 - **vehicle_position_url** (*Optional*): Provides live bus position tracking on the home assistant map
-- **static_schedule_url** (*Optional*): A static GTFS ZIP feed used to validate whether a stop is valid and whether service should currently exist. When configured, the entity stays `unknown` during normal no-service windows, but becomes `unavailable` when the route/stop is invalid or scheduled service should exist and the realtime feed has no matching departures.
+- **static_schedule_url** (*Optional*): A static GTFS ZIP feed used to validate whether a stop is valid and whether service should currently exist. When configured, the entity stays `unknown` during normal no-service windows, and also stays `unknown` when a valid route/stop pair is missing from a truncated realtime stop list. It becomes `unavailable` when the route/stop is invalid or when the realtime feed itself cannot be fetched.
 - **headers**(*Optional*): Expects a dictionary. If provided, the dictionary will be sent as headers. (e.g. {"Authorization": "mykey"})
 - **departures** (*Required*): A list of routes and departure locations to watch
 - **unique_id** (*Optional*): A UUID for the entity to allow entity registry entries

--- a/custom_components/gtfs_rt/availability.py
+++ b/custom_components/gtfs_rt/availability.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from .health import STATUS_LOOKUP_FAILED, ScheduleStatus
+
+
+def should_mark_entity_unavailable(
+    *,
+    last_trip_update_error: str | None,
+    schedule_status: ScheduleStatus | None,
+    has_realtime_departures: bool,
+) -> bool:
+    """Return whether the entity should be marked unavailable."""
+    if last_trip_update_error:
+        return True
+    if schedule_status is None or schedule_status.status == STATUS_LOOKUP_FAILED:
+        return False
+    if schedule_status.is_config_problem:
+        return True
+    # Some agencies publish realtime trip updates with truncated stop lists. When
+    # the route/stop pair is valid in the static schedule, keep the entity
+    # available so the state can remain unknown instead of looking broken.
+    if schedule_status.service_expected_now and not has_realtime_departures:
+        return False
+    return False

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import Throttle
 
+from .availability import should_mark_entity_unavailable
 from .config import FEED_CONFIG_SCHEMA, normalize_feed_config
 from .const import (
     CONF_DEPARTURES,
@@ -197,16 +198,11 @@ class PublicTransportSensor(SensorEntity):
     def available(self):
         next_buses = self._get_next_buses()
         schedule_status = self._get_schedule_status()
-
-        if self.data.last_trip_update_error:
-            return False
-        if schedule_status is None or schedule_status.status == STATUS_LOOKUP_FAILED:
-            return True
-        if schedule_status.is_config_problem:
-            return False
-        if schedule_status.status == STATUS_SERVICE_EXPECTED and len(next_buses) == 0:
-            return False
-        return True
+        return not should_mark_entity_unavailable(
+            last_trip_update_error=self.data.last_trip_update_error,
+            schedule_status=schedule_status,
+            has_realtime_departures=len(next_buses) > 0,
+        )
 
     @property
     def extra_state_attributes(self):

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,0 +1,93 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+sys.modules.setdefault("requests", types.SimpleNamespace(get=None))
+
+HEALTH_SPEC = importlib.util.spec_from_file_location(
+    "gtfs_rt_health",
+    ROOT / "custom_components" / "gtfs_rt" / "health.py",
+)
+HEALTH = importlib.util.module_from_spec(HEALTH_SPEC)
+assert HEALTH_SPEC and HEALTH_SPEC.loader
+sys.modules[HEALTH_SPEC.name] = HEALTH
+HEALTH_SPEC.loader.exec_module(HEALTH)
+
+PACKAGE = types.ModuleType("custom_components.gtfs_rt")
+PACKAGE.__path__ = [str(ROOT / "custom_components" / "gtfs_rt")]
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules["custom_components.gtfs_rt"] = PACKAGE
+sys.modules["custom_components.gtfs_rt.health"] = HEALTH
+
+AVAILABILITY_SPEC = importlib.util.spec_from_file_location(
+    "custom_components.gtfs_rt.availability",
+    ROOT / "custom_components" / "gtfs_rt" / "availability.py",
+)
+AVAILABILITY = importlib.util.module_from_spec(AVAILABILITY_SPEC)
+assert AVAILABILITY_SPEC and AVAILABILITY_SPEC.loader
+sys.modules[AVAILABILITY_SPEC.name] = AVAILABILITY
+AVAILABILITY_SPEC.loader.exec_module(AVAILABILITY)
+
+ScheduleStatus = HEALTH.ScheduleStatus
+STATUS_INVALID_STOP = HEALTH.STATUS_INVALID_STOP
+STATUS_SERVICE_EXPECTED = HEALTH.STATUS_SERVICE_EXPECTED
+should_mark_entity_unavailable = AVAILABILITY.should_mark_entity_unavailable
+
+
+class AvailabilityTests(unittest.TestCase):
+    def test_trip_update_error_marks_entity_unavailable(self):
+        self.assertTrue(
+            should_mark_entity_unavailable(
+                last_trip_update_error="timeout",
+                schedule_status=None,
+                has_realtime_departures=False,
+            )
+        )
+
+    def test_invalid_stop_marks_entity_unavailable(self):
+        schedule_status = ScheduleStatus(
+            status=STATUS_INVALID_STOP,
+            route_exists=True,
+            stop_exists=False,
+            route_serves_stop=False,
+            service_today=False,
+            service_expected_now=False,
+            next_scheduled_departure=None,
+            problem_reason="bad stop",
+        )
+
+        self.assertTrue(
+            should_mark_entity_unavailable(
+                last_trip_update_error=None,
+                schedule_status=schedule_status,
+                has_realtime_departures=False,
+            )
+        )
+
+    def test_missing_realtime_departures_during_service_stays_available(self):
+        schedule_status = ScheduleStatus(
+            status=STATUS_SERVICE_EXPECTED,
+            route_exists=True,
+            stop_exists=True,
+            route_serves_stop=True,
+            service_today=True,
+            service_expected_now=True,
+            next_scheduled_departure=None,
+            problem_reason=None,
+        )
+
+        self.assertFalse(
+            should_mark_entity_unavailable(
+                last_trip_update_error=None,
+                schedule_status=schedule_status,
+                has_realtime_departures=False,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep GTFS sensors `unknown` when a valid route/stop pair is simply missing from a truncated realtime stop list
- continue marking sensors `unavailable` for actual config problems like invalid route/stop IDs or realtime endpoint failures
- add focused availability tests and update the README to document the new behavior

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall custom_components tests`
