### PR TITLE
Fix imported GTFS entries staying not loaded

### DIFF
--- a/custom_components/gtfs_rt/__init__.py
+++ b/custom_components/gtfs_rt/__init__.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 
 from .config import FEED_CONFIG_SCHEMA, normalize_feed_config
-from .const import DOMAIN
+from .const import CONF_FEED_ID, DOMAIN
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -21,17 +24,39 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass, config):
     """Import YAML feed definitions into config entries."""
     hass.data.setdefault(DOMAIN, {})
+    import_tasks = []
+    configured_feed_ids = set()
 
     for raw_feed in config.get(DOMAIN, []):
-        hass.async_create_task(
+        normalized = normalize_feed_config(dict(raw_feed))
+        configured_feed_ids.add(normalized[CONF_FEED_ID])
+        import_tasks.append(
+            hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": "import"},
-                data=normalize_feed_config(dict(raw_feed)),
+                data=normalized,
+            )
             )
         )
 
+    if import_tasks:
+        hass.async_create_task(_async_setup_imported_entries(hass, import_tasks, configured_feed_ids))
+
     return True
+
+
+async def _async_setup_imported_entries(hass, import_tasks, configured_feed_ids):
+    """Finish YAML imports and ensure matching entries are actively set up."""
+    await asyncio.gather(*import_tasks)
+    await asyncio.sleep(0)
+
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.data.get(CONF_FEED_ID) not in configured_feed_ids:
+            continue
+        if entry.disabled_by or entry.state is not ConfigEntryState.NOT_LOADED:
+            continue
+        await hass.config_entries.async_setup(entry.entry_id)
 
 
 async def async_setup_entry(hass, entry):

--- a/custom_components/gtfs_rt/config_flow.py
+++ b/custom_components/gtfs_rt/config_flow.py
@@ -26,7 +26,8 @@ class GTFSRtConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 continue
             if entry.data != data or entry.title != data[CONF_NAME]:
                 self.hass.config_entries.async_update_entry(entry, data=data, title=data[CONF_NAME])
-                await self.hass.config_entries.async_reload(entry.entry_id)
+                if entry.state is config_entries.ConfigEntryState.LOADED:
+                    self.hass.config_entries.async_schedule_reload(entry.entry_id)
             return self.async_abort(reason="already_configured")
 
         return self.async_create_entry(title=data[CONF_NAME], data=data)

--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -5,7 +5,7 @@
     "dependencies": [],
     "codeowners": ["@Jason-Morcos"],
     "config_flow": true,
-    "version": "1.4.0",
+    "version": "1.4.1",
     "requirements": [
         "gtfs-realtime-bindings==1.0.0"
     ]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = ROOT / "custom_components" / "gtfs_rt"
+
+
+class FakeConfigFlow:
+    def __init_subclass__(cls, domain=None, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.domain = domain
+
+    def async_abort(self, reason):
+        return {"type": "abort", "reason": reason}
+
+    def async_create_entry(self, title, data):
+        return {"type": "create_entry", "title": title, "data": data}
+
+
+class FakeConfigEntryState:
+    LOADED = "loaded"
+    NOT_LOADED = "not_loaded"
+
+
+homeassistant = types.ModuleType("homeassistant")
+config_entries = types.ModuleType("homeassistant.config_entries")
+config_entries.ConfigFlow = FakeConfigFlow
+config_entries.ConfigEntryState = FakeConfigEntryState
+const = types.ModuleType("homeassistant.const")
+const.CONF_NAME = "name"
+homeassistant.config_entries = config_entries
+homeassistant.const = const
+
+sys.modules["homeassistant"] = homeassistant
+sys.modules["homeassistant.config_entries"] = config_entries
+sys.modules["homeassistant.const"] = const
+
+package = types.ModuleType("custom_components.gtfs_rt")
+package.__path__ = [str(PACKAGE_ROOT)]
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules["custom_components.gtfs_rt"] = package
+
+config_module = types.ModuleType("custom_components.gtfs_rt.config")
+config_module.normalize_feed_config = lambda data: data
+sys.modules["custom_components.gtfs_rt.config"] = config_module
+
+const_module = types.ModuleType("custom_components.gtfs_rt.const")
+const_module.CONF_FEED_ID = "feed_id"
+const_module.DOMAIN = "gtfs_rt"
+sys.modules["custom_components.gtfs_rt.const"] = const_module
+
+SPEC = importlib.util.spec_from_file_location(
+    "custom_components.gtfs_rt.config_flow",
+    PACKAGE_ROOT / "config_flow.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeConfigEntriesManager:
+    def __init__(self, entries):
+        self._entries = entries
+        self.updated = []
+        self.reloaded = []
+
+    def async_entries(self, _domain):
+        return list(self._entries)
+
+    def async_update_entry(self, entry, **kwargs):
+        self.updated.append((entry, kwargs))
+
+    def async_schedule_reload(self, entry_id):
+        self.reloaded.append(entry_id)
+
+
+class ConfigFlowImportTests(unittest.IsolatedAsyncioTestCase):
+    async def test_import_updates_not_loaded_entry_without_reloading(self):
+        entry = types.SimpleNamespace(
+            data={"feed_id": "feed-1", "name": "Old"},
+            title="Old",
+            entry_id="entry-1",
+            state=FakeConfigEntryState.NOT_LOADED,
+        )
+        manager = FakeConfigEntriesManager([entry])
+        flow = MODULE.GTFSRtConfigFlow()
+        flow.hass = types.SimpleNamespace(config_entries=manager)
+
+        result = await flow.async_step_import({"feed_id": "feed-1", "name": "New"})
+
+        self.assertEqual(result, {"type": "abort", "reason": "already_configured"})
+        self.assertEqual(len(manager.updated), 1)
+        self.assertEqual(manager.reloaded, [])
+
+    async def test_import_updates_loaded_entry_and_schedules_reload(self):
+        entry = types.SimpleNamespace(
+            data={"feed_id": "feed-1", "name": "Old"},
+            title="Old",
+            entry_id="entry-1",
+            state=FakeConfigEntryState.LOADED,
+        )
+        manager = FakeConfigEntriesManager([entry])
+        flow = MODULE.GTFSRtConfigFlow()
+        flow.hass = types.SimpleNamespace(config_entries=manager)
+
+        result = await flow.async_step_import({"feed_id": "feed-1", "name": "New"})
+
+        self.assertEqual(result, {"type": "abort", "reason": "already_configured"})
+        self.assertEqual(len(manager.updated), 1)
+        self.assertEqual(manager.reloaded, ["entry-1"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid reloading imported entries while the integration domain is still being initialized
- explicitly set up matching imported entries after YAML import tasks finish
- add regression coverage for import behavior and bump the component version

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall custom_components tests`