### PR TITLE
Add safeguards for stop-level arrivals fallback

### DIFF
--- a/custom_components/gtfs_rt/realtime.py
+++ b/custom_components/gtfs_rt/realtime.py
@@ -31,10 +31,11 @@ def normalize_prefixed_id(value: str | None) -> str | None:
 
 def route_id_matches(configured_route: str, observed_route: str | None) -> bool:
     """Match a configured route id against a provider route id."""
+    configured = normalize_prefixed_id(configured_route)
     observed = normalize_prefixed_id(observed_route)
-    if observed is None:
+    if configured is None or observed is None:
         return False
-    return str(configured_route) == observed
+    return configured == observed
 
 
 def build_onebusaway_stop_details(item: dict) -> StopDetails | None:

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -292,7 +292,16 @@ class PublicTransportData:
         self.info = {}
 
         if self._stop_arrivals_url_template:
-            self._update_stop_arrival_statuses()
+            stop_arrivals_error = self._update_stop_arrival_statuses()
+            if stop_arrivals_error:
+                _LOGGER.warning("Falling back to trip updates after stop-level arrivals failure")
+                self.last_trip_update_error = None
+                positions, vehicles_trips, occupancy = (
+                    self._get_vehicle_positions() if self._vehicle_position_url else ({}, {}, {})
+                )
+                self._update_route_statuses(positions, vehicles_trips, occupancy)
+                if self.last_trip_update_error:
+                    self.last_trip_update_error = f"{stop_arrivals_error}; {self.last_trip_update_error}"
         else:
             positions, vehicles_trips, occupancy = (
                 self._get_vehicle_positions() if self._vehicle_position_url else ({}, {}, {})
@@ -323,18 +332,19 @@ class PublicTransportData:
             except Exception as err:
                 self.last_trip_update_error = f"Stop-level arrivals unavailable: {err}"
                 _LOGGER.error("Unable to refresh stop-level arrivals: %s", err)
-                return
+                return self.last_trip_update_error
 
             if payload.get("code") not in (None, 200):
                 self.last_trip_update_error = f"Stop-level arrivals unavailable: API code {payload.get('code')}"
                 _LOGGER.error("Unexpected stop-level arrivals payload code: %s", payload.get("code"))
-                return
+                return self.last_trip_update_error
 
             entry = (payload.get("data") or {}).get("entry") or {}
             arrivals = entry.get("arrivalsAndDepartures") or []
             departure_times[route_id][stop_id] = filter_onebusaway_arrivals(arrivals, route_id, now)
 
         self.info = departure_times
+        return None
 
     def _update_route_statuses(self, vehicle_positions, vehicles_trips, vehicle_occupancy):
         from google.transit import gtfs_realtime_pb2

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -54,6 +54,7 @@ ATTR_NEXT_SCHEDULED_DEPARTURE = "Next scheduled departure"
 ATTR_PROBLEM_REASON = "Problem reason"
 
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=60)
+DEFAULT_STOP_ARRIVALS_BACKOFF = datetime.timedelta(minutes=5)
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(FEED_CONFIG_SCHEMA)
@@ -277,6 +278,8 @@ class PublicTransportData:
         self.info = {}
         self.last_trip_update_error = None
         self._schedule_status = {}
+        self._last_stop_arrival_info = {}
+        self._stop_arrivals_backoff_until = None
 
     def get_schedule_status(self, route_id, stop_id):
         return self._schedule_status.get((route_id, stop_id))
@@ -319,6 +322,17 @@ class PublicTransportData:
 
     def _update_stop_arrival_statuses(self):
         now = dt_util.now().replace(tzinfo=None)
+        cached_departures = self._future_departure_times(self._last_stop_arrival_info, now)
+
+        if self._stop_arrivals_backoff_until and now < self._stop_arrivals_backoff_until:
+            self.info = cached_departures
+            if cached_departures:
+                return None
+            return (
+                "Stop-level arrivals temporarily rate limited until "
+                f"{self._stop_arrivals_backoff_until.strftime(TIME_STR_FORMAT)}"
+            )
+
         departure_times = {}
 
         for route_id, stop_id in self._monitored_departures:
@@ -327,6 +341,20 @@ class PublicTransportData:
             try:
                 url = self._stop_arrivals_url_template.format(stop_id=stop_id)
                 response = requests.get(url, headers=self._headers, timeout=REQUEST_TIMEOUT)
+                if response.status_code == 429:
+                    retry_after = self._get_stop_arrivals_retry_after(response)
+                    self._stop_arrivals_backoff_until = now + retry_after
+                    self.info = cached_departures
+                    _LOGGER.warning(
+                        "Stop-level arrivals rate limited; backing off until %s",
+                        self._stop_arrivals_backoff_until.strftime(TIME_STR_FORMAT),
+                    )
+                    if cached_departures:
+                        return None
+                    return (
+                        "Stop-level arrivals temporarily rate limited until "
+                        f"{self._stop_arrivals_backoff_until.strftime(TIME_STR_FORMAT)}"
+                    )
                 response.raise_for_status()
                 payload = response.json()
             except Exception as err:
@@ -344,7 +372,32 @@ class PublicTransportData:
             departure_times[route_id][stop_id] = filter_onebusaway_arrivals(arrivals, route_id, now)
 
         self.info = departure_times
+        self._last_stop_arrival_info = departure_times
+        self._stop_arrivals_backoff_until = None
         return None
+
+    @staticmethod
+    def _future_departure_times(departure_times, now):
+        future_departures = {}
+        for route_id, stops in (departure_times or {}).items():
+            future_departures[route_id] = {}
+            for stop_id, details in stops.items():
+                future_departures[route_id][stop_id] = [
+                    detail for detail in details if detail.arrival_time > now
+                ]
+        return future_departures
+
+    @staticmethod
+    def _get_stop_arrivals_retry_after(response):
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                seconds = int(retry_after)
+            except ValueError:
+                seconds = None
+            if seconds is not None and seconds > 0:
+                return datetime.timedelta(seconds=seconds)
+        return DEFAULT_STOP_ARRIVALS_BACKOFF
 
     def _update_route_statuses(self, vehicle_positions, vehicles_trips, vehicle_occupancy):
         from google.transit import gtfs_realtime_pb2

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -19,6 +19,8 @@ route_id_matches = REALTIME.route_id_matches
 class RealtimeTests(unittest.TestCase):
     def test_route_id_matches_agency_prefixed_ids(self):
         self.assertTrue(route_id_matches("100214", "1_100214"))
+        self.assertTrue(route_id_matches("1_100214", "100214"))
+        self.assertTrue(route_id_matches("1_100214", "1_100214"))
         self.assertFalse(route_id_matches("100214", "1_100341"))
 
     def test_filter_onebusaway_arrivals_uses_future_scheduled_or_predicted_times(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,6 +2,7 @@ import importlib.util
 import sys
 import types
 import unittest
+import datetime as dt
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -114,6 +115,7 @@ sys.modules[sensor_spec.name] = sensor_module
 sensor_spec.loader.exec_module(sensor_module)
 
 PublicTransportData = sensor_module.PublicTransportData
+StopDetails = realtime_module.StopDetails
 
 
 class SensorUpdateTests(unittest.TestCase):
@@ -144,6 +146,67 @@ class SensorUpdateTests(unittest.TestCase):
         self.assertEqual(calls, ["fallback"])
         self.assertIsNone(data.last_trip_update_error)
         self.assertEqual(data.info, {"100214": {"1234": ["departure"]}})
+
+    def test_rate_limited_stop_arrivals_reuse_cached_data(self):
+        now = dt.datetime(2026, 4, 3, 16, 0, 0)
+        dt_mod.now = lambda: now
+        data = PublicTransportData(
+            trip_update_url="https://example.com/tripupdates.pb",
+            vehicle_position_url=None,
+            headers={},
+            monitored_departures=[("100214", "1234")],
+            static_schedule_url=None,
+            stop_arrivals_url_template="https://example.com/{stop_id}",
+        )
+        future_departure = StopDetails(now + dt.timedelta(minutes=4), None, None, None)
+        past_departure = StopDetails(now - dt.timedelta(minutes=1), None, None, None)
+        data._last_stop_arrival_info = {"100214": {"1234": [past_departure, future_departure]}}
+        fallback_calls = []
+
+        class FakeResponse:
+            status_code = 429
+            headers = {"Retry-After": "120"}
+
+            def raise_for_status(self):
+                raise AssertionError("raise_for_status should not be called for 429 handling")
+
+        sensor_module.requests.get = lambda *args, **kwargs: FakeResponse()
+        data._update_route_statuses = lambda *_args: fallback_calls.append("fallback")
+
+        data.update()
+
+        self.assertEqual(fallback_calls, [])
+        self.assertEqual(data.info, {"100214": {"1234": [future_departure]}})
+        self.assertIsNone(data.last_trip_update_error)
+        self.assertEqual(data._stop_arrivals_backoff_until, now + dt.timedelta(seconds=120))
+
+    def test_rate_limit_backoff_skips_network_requests(self):
+        now = dt.datetime(2026, 4, 3, 16, 0, 0)
+        dt_mod.now = lambda: now
+        data = PublicTransportData(
+            trip_update_url="https://example.com/tripupdates.pb",
+            vehicle_position_url=None,
+            headers={},
+            monitored_departures=[("100214", "1234")],
+            static_schedule_url=None,
+            stop_arrivals_url_template="https://example.com/{stop_id}",
+        )
+        future_departure = StopDetails(now + dt.timedelta(minutes=3), None, None, None)
+        data._last_stop_arrival_info = {"100214": {"1234": [future_departure]}}
+        data._stop_arrivals_backoff_until = now + dt.timedelta(minutes=2)
+        fallback_calls = []
+
+        def unexpected_get(*_args, **_kwargs):
+            raise AssertionError("requests.get should not run during stop-arrivals backoff")
+
+        sensor_module.requests.get = unexpected_get
+        data._update_route_statuses = lambda *_args: fallback_calls.append("fallback")
+
+        data.update()
+
+        self.assertEqual(fallback_calls, [])
+        self.assertEqual(data.info, {"100214": {"1234": [future_departure]}})
+        self.assertIsNone(data.last_trip_update_error)
 
 
 if __name__ == "__main__":

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,150 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = ROOT / "custom_components" / "gtfs_rt"
+
+sys.modules.setdefault("requests", types.SimpleNamespace(get=None))
+
+homeassistant = types.ModuleType("homeassistant")
+sys.modules["homeassistant"] = homeassistant
+
+util_pkg = types.ModuleType("homeassistant.util")
+
+
+def throttle(_interval):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+util_pkg.Throttle = throttle
+sys.modules["homeassistant.util"] = util_pkg
+
+dt_mod = types.ModuleType("homeassistant.util.dt")
+dt_mod.now = lambda: None
+sys.modules["homeassistant.util.dt"] = dt_mod
+util_pkg.dt = dt_mod
+
+sensor_mod = types.ModuleType("homeassistant.components.sensor")
+
+
+class PlatformSchema:
+    def extend(self, _schema):
+        return self
+
+
+class SensorEntity:
+    pass
+
+
+sensor_mod.PLATFORM_SCHEMA = PlatformSchema()
+sensor_mod.SensorEntity = SensorEntity
+sys.modules["homeassistant.components"] = types.ModuleType("homeassistant.components")
+sys.modules["homeassistant.components.sensor"] = sensor_mod
+
+const_mod = types.ModuleType("homeassistant.const")
+const_mod.ATTR_LATITUDE = "latitude"
+const_mod.ATTR_LONGITUDE = "longitude"
+const_mod.CONF_NAME = "name"
+const_mod.CONF_UNIQUE_ID = "unique_id"
+const_mod.UnitOfTime = types.SimpleNamespace(MINUTES="min")
+sys.modules["homeassistant.const"] = const_mod
+
+helpers_pkg = types.ModuleType("homeassistant.helpers")
+sys.modules["homeassistant.helpers"] = helpers_pkg
+
+device_registry_mod = types.ModuleType("homeassistant.helpers.device_registry")
+device_registry_mod.DeviceEntryType = types.SimpleNamespace(SERVICE="service")
+sys.modules["homeassistant.helpers.device_registry"] = device_registry_mod
+
+entity_mod = types.ModuleType("homeassistant.helpers.entity")
+entity_mod.DeviceInfo = dict
+sys.modules["homeassistant.helpers.entity"] = entity_mod
+
+package = types.ModuleType("custom_components.gtfs_rt")
+package.__path__ = [str(PACKAGE_ROOT)]
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules["custom_components.gtfs_rt"] = package
+
+availability_mod = types.ModuleType("custom_components.gtfs_rt.availability")
+availability_mod.should_mark_entity_unavailable = lambda **kwargs: False
+sys.modules["custom_components.gtfs_rt.availability"] = availability_mod
+
+config_mod = types.ModuleType("custom_components.gtfs_rt.config")
+config_mod.FEED_CONFIG_SCHEMA = {}
+config_mod.normalize_feed_config = lambda data: data
+sys.modules["custom_components.gtfs_rt.config"] = config_mod
+
+const_spec = importlib.util.spec_from_file_location(
+    "custom_components.gtfs_rt.const",
+    PACKAGE_ROOT / "const.py",
+)
+const_module = importlib.util.module_from_spec(const_spec)
+assert const_spec and const_spec.loader
+sys.modules[const_spec.name] = const_module
+const_spec.loader.exec_module(const_module)
+
+health_mod = types.ModuleType("custom_components.gtfs_rt.health")
+health_mod.STATUS_LOOKUP_FAILED = "schedule_lookup_failed"
+health_mod.STATUS_SERVICE_EXPECTED = "service_expected"
+health_mod.StaticScheduleValidator = object
+sys.modules["custom_components.gtfs_rt.health"] = health_mod
+
+realtime_spec = importlib.util.spec_from_file_location(
+    "custom_components.gtfs_rt.realtime",
+    PACKAGE_ROOT / "realtime.py",
+)
+realtime_module = importlib.util.module_from_spec(realtime_spec)
+assert realtime_spec and realtime_spec.loader
+sys.modules[realtime_spec.name] = realtime_module
+realtime_spec.loader.exec_module(realtime_module)
+
+sensor_spec = importlib.util.spec_from_file_location(
+    "custom_components.gtfs_rt.sensor",
+    PACKAGE_ROOT / "sensor.py",
+)
+sensor_module = importlib.util.module_from_spec(sensor_spec)
+assert sensor_spec and sensor_spec.loader
+sys.modules[sensor_spec.name] = sensor_module
+sensor_spec.loader.exec_module(sensor_module)
+
+PublicTransportData = sensor_module.PublicTransportData
+
+
+class SensorUpdateTests(unittest.TestCase):
+    def test_stop_arrivals_failure_falls_back_to_trip_updates(self):
+        data = PublicTransportData(
+            trip_update_url="https://example.com/tripupdates.pb",
+            vehicle_position_url=None,
+            headers={},
+            monitored_departures=[("100214", "1234")],
+            static_schedule_url=None,
+            stop_arrivals_url_template="https://example.com/{stop_id}",
+        )
+        calls = []
+
+        def fail_stop_arrivals():
+            data.last_trip_update_error = "Stop-level arrivals unavailable: boom"
+            return data.last_trip_update_error
+
+        def fallback_trip_updates(_positions, _vehicles_trips, _occupancy):
+            calls.append("fallback")
+            data.info = {"100214": {"1234": ["departure"]}}
+
+        data._update_stop_arrival_statuses = fail_stop_arrivals
+        data._update_route_statuses = fallback_trip_updates
+
+        data.update()
+
+        self.assertEqual(calls, ["fallback"])
+        self.assertIsNone(data.last_trip_update_error)
+        self.assertEqual(data.info, {"100214": {"1234": ["departure"]}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fall back to GTFS trip updates if the optional stop-level arrivals backend is unavailable
- normalize configured route IDs before comparing them to provider route IDs
- add regression tests for both cases

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall custom_components tests`