### PR TITLE
Fix route matching and empty stop-arrival cache handling

### DIFF
--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -5,7 +5,7 @@
     "dependencies": [],
     "codeowners": ["@Jason-Morcos"],
     "config_flow": true,
-    "version": "1.4.0",
+    "version": "1.4.2",
     "requirements": [
         "gtfs-realtime-bindings==1.0.0"
     ]

--- a/custom_components/gtfs_rt/realtime.py
+++ b/custom_components/gtfs_rt/realtime.py
@@ -29,13 +29,29 @@ def normalize_prefixed_id(value: str | None) -> str | None:
     return text
 
 
+def has_numeric_prefix(value: str | None) -> bool:
+    """Return whether an id uses a numeric agency prefix like `1_100214`."""
+    if value is None:
+        return False
+    text = str(value)
+    prefix, separator, _remainder = text.partition("_")
+    return bool(separator and prefix.isdigit())
+
+
 def route_id_matches(configured_route: str, observed_route: str | None) -> bool:
     """Match a configured route id against a provider route id."""
-    configured = normalize_prefixed_id(configured_route)
-    observed = normalize_prefixed_id(observed_route)
-    if configured is None or observed is None:
+    configured = str(configured_route)
+    if observed_route is None:
         return False
-    return configured == observed
+    observed = str(observed_route)
+
+    if has_numeric_prefix(configured):
+        return configured == observed
+
+    normalized_observed = normalize_prefixed_id(observed)
+    if normalized_observed is None:
+        return False
+    return configured == normalized_observed
 
 
 def build_onebusaway_stop_details(item: dict) -> StopDetails | None:

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -326,7 +326,7 @@ class PublicTransportData:
 
         if self._stop_arrivals_backoff_until and now < self._stop_arrivals_backoff_until:
             self.info = cached_departures
-            if cached_departures:
+            if self._has_departures(cached_departures):
                 return None
             return (
                 "Stop-level arrivals temporarily rate limited until "
@@ -349,7 +349,7 @@ class PublicTransportData:
                         "Stop-level arrivals rate limited; backing off until %s",
                         self._stop_arrivals_backoff_until.strftime(TIME_STR_FORMAT),
                     )
-                    if cached_departures:
+                    if self._has_departures(cached_departures):
                         return None
                     return (
                         "Stop-level arrivals temporarily rate limited until "
@@ -386,6 +386,14 @@ class PublicTransportData:
                     detail for detail in details if detail.arrival_time > now
                 ]
         return future_departures
+
+    @staticmethod
+    def _has_departures(departure_times):
+        return any(
+            details
+            for stops in (departure_times or {}).values()
+            for details in stops.values()
+        )
 
     @staticmethod
     def _get_stop_arrivals_retry_after(response):

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -19,8 +19,9 @@ route_id_matches = REALTIME.route_id_matches
 class RealtimeTests(unittest.TestCase):
     def test_route_id_matches_agency_prefixed_ids(self):
         self.assertTrue(route_id_matches("100214", "1_100214"))
-        self.assertTrue(route_id_matches("1_100214", "100214"))
         self.assertTrue(route_id_matches("1_100214", "1_100214"))
+        self.assertFalse(route_id_matches("1_100214", "100214"))
+        self.assertFalse(route_id_matches("1_100214", "2_100214"))
         self.assertFalse(route_id_matches("100214", "1_100341"))
 
     def test_filter_onebusaway_arrivals_uses_future_scheduled_or_predicted_times(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -208,6 +208,37 @@ class SensorUpdateTests(unittest.TestCase):
         self.assertEqual(data.info, {"100214": {"1234": [future_departure]}})
         self.assertIsNone(data.last_trip_update_error)
 
+    def test_rate_limit_backoff_with_empty_cached_lists_falls_back_to_trip_updates(self):
+        now = dt.datetime(2026, 4, 3, 16, 0, 0)
+        dt_mod.now = lambda: now
+        data = PublicTransportData(
+            trip_update_url="https://example.com/tripupdates.pb",
+            vehicle_position_url=None,
+            headers={},
+            monitored_departures=[("100214", "1234")],
+            static_schedule_url=None,
+            stop_arrivals_url_template="https://example.com/{stop_id}",
+        )
+        data._last_stop_arrival_info = {"100214": {"1234": []}}
+        data._stop_arrivals_backoff_until = now + dt.timedelta(minutes=2)
+        fallback_calls = []
+
+        def unexpected_get(*_args, **_kwargs):
+            raise AssertionError("requests.get should not run during stop-arrivals backoff")
+
+        def fallback_trip_updates(_positions, _vehicles_trips, _occupancy):
+            fallback_calls.append("fallback")
+            data.info = {"100214": {"1234": ["departure"]}}
+
+        sensor_module.requests.get = unexpected_get
+        data._update_route_statuses = fallback_trip_updates
+
+        data.update()
+
+        self.assertEqual(fallback_calls, ["fallback"])
+        self.assertEqual(data.info, {"100214": {"1234": ["departure"]}})
+        self.assertIsNone(data.last_trip_update_error)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- preserve explicit agency prefixes when matching configured route IDs against provider route IDs
- only treat cached stop-arrival data as usable when it contains actual future departures
- add regression coverage for both cases and bump the component version

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall custom_components tests`