### PR TITLE
Add upcoming departure attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ When `static_schedule_url` is configured, each sensor also adds:
 - `Next scheduled departure`
 - `Problem reason`
 
+Each sensor also exposes `Upcoming departures`, a list of up to five upcoming trips with:
+
+- `due_at`
+- `due_in`
+- `delay_minutes`
+- `occupancy`
+- `latitude` / `longitude` when live vehicle position data is available
+
 When the feed is configured under the top-level `gtfs_rt:` key, the integration imports it into a Home Assistant config entry. That allows each route to appear as its own service device, so a line like `372` can group all of your chosen stops under a single device.
 
 If both `trip_update_url` and `stop_arrivals_url_template` are configured, the stop-level arrivals endpoint is used as the primary realtime source and the trip-update feed remains available as a compatibility fallback in the configuration.

--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -5,7 +5,7 @@
     "dependencies": [],
     "codeowners": ["@Jason-Morcos"],
     "config_flow": true,
-    "version": "1.4.2",
+    "version": "1.4.3",
     "requirements": [
         "gtfs-realtime-bindings==1.0.0"
     ]

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -47,6 +47,7 @@ ATTR_NEXT_UP = "Next bus"
 ATTR_NEXT_UP_DUE_IN = "Next bus due in"
 ATTR_NEXT_DELAYED_BY = "Next bus delayed by"
 ATTR_NEXT_OCCUPANCY = "Next bus occupancy"
+ATTR_UPCOMING_DEPARTURES = "Upcoming departures"
 ATTR_SERVICE_STATUS = "Service status"
 ATTR_SERVICE_TODAY = "Service today"
 ATTR_SERVICE_EXPECTED_NOW = "Service expected now"
@@ -55,6 +56,7 @@ ATTR_PROBLEM_REASON = "Problem reason"
 
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=60)
 DEFAULT_STOP_ARRIVALS_BACKOFF = datetime.timedelta(minutes=5)
+MAX_UPCOMING_DEPARTURES = 5
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(FEED_CONFIG_SCHEMA)
@@ -76,6 +78,20 @@ def due_in_minutes(timestamp):
     """Get the remaining minutes from now until a given datetime object."""
     diff = timestamp - dt_util.now().replace(tzinfo=None)
     return int(diff.total_seconds() / 60)
+
+
+def departure_attributes(detail):
+    """Serialize a realtime departure into state attributes."""
+    attrs = {
+        "due_at": detail.arrival_time.strftime(TIME_STR_FORMAT),
+        "due_in": due_in_minutes(detail.arrival_time),
+        "delay_minutes": detail.delay / 60.0 if detail.delay else None,
+        "occupancy": detail.occupancy,
+    }
+    if detail.position:
+        attrs["latitude"] = detail.position.latitude
+        attrs["longitude"] = detail.position.longitude
+    return attrs
 
 
 def _build_shared_data(config):
@@ -223,6 +239,7 @@ class PublicTransportSensor(SensorEntity):
             ATTR_NEXT_UP: None,
             ATTR_NEXT_DELAYED_BY: None,
             ATTR_NEXT_OCCUPANCY: None,
+            ATTR_UPCOMING_DEPARTURES: [],
             ATTR_STOP_ID: self._stop,
             ATTR_ROUTE: self._route,
             ATTR_SERVICE_STATUS: schedule_status.status if schedule_status else None,
@@ -247,6 +264,10 @@ class PublicTransportSensor(SensorEntity):
             attrs[ATTR_NEXT_UP_DUE_IN] = due_in_minutes(next_buses[1].arrival_time)
             attrs[ATTR_NEXT_OCCUPANCY] = next_buses[1].occupancy
             attrs[ATTR_NEXT_DELAYED_BY] = next_buses[1].delay / 60.0 if next_buses[1].delay else None
+        if next_buses:
+            attrs[ATTR_UPCOMING_DEPARTURES] = [
+                departure_attributes(detail) for detail in next_buses[:MAX_UPCOMING_DEPARTURES]
+            ]
         return attrs
 
     def update(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -115,10 +115,71 @@ sys.modules[sensor_spec.name] = sensor_module
 sensor_spec.loader.exec_module(sensor_module)
 
 PublicTransportData = sensor_module.PublicTransportData
+PublicTransportSensor = sensor_module.PublicTransportSensor
 StopDetails = realtime_module.StopDetails
+RealtimePosition = realtime_module.RealtimePosition
 
 
 class SensorUpdateTests(unittest.TestCase):
+    def test_sensor_exposes_upcoming_departures_attribute(self):
+        now = dt.datetime(2026, 4, 3, 16, 0, 0)
+        dt_mod.now = lambda: now
+        next_buses = [
+            StopDetails(
+                now + dt.timedelta(minutes=2),
+                RealtimePosition(47.1, -122.1),
+                "FEW_SEATS_AVAILABLE",
+                120,
+            ),
+            StopDetails(now + dt.timedelta(minutes=9), None, "STANDING_ROOM_ONLY", 300),
+            StopDetails(now + dt.timedelta(minutes=17), None, None, None),
+            StopDetails(now + dt.timedelta(minutes=24), None, None, None),
+            StopDetails(now + dt.timedelta(minutes=31), None, None, None),
+            StopDetails(now + dt.timedelta(minutes=38), None, None, None),
+        ]
+
+        class FakeData:
+            def __init__(self):
+                self.info = {"100214": {"1234": next_buses}}
+                self.last_trip_update_error = None
+
+            def get_schedule_status(self, _route, _stop):
+                return None
+
+        sensor = PublicTransportSensor(
+            data=FakeData(),
+            stop="1234",
+            route="100214",
+            name="Route 372",
+            unique_id="test-unique-id",
+        )
+
+        attrs = sensor.extra_state_attributes
+
+        self.assertEqual(sensor.state, 2)
+        self.assertEqual(attrs[sensor_module.ATTR_NEXT_UP], "16:09")
+        self.assertEqual(len(attrs[sensor_module.ATTR_UPCOMING_DEPARTURES]), 5)
+        self.assertEqual(
+            attrs[sensor_module.ATTR_UPCOMING_DEPARTURES][0],
+            {
+                "due_at": "16:02",
+                "due_in": 2,
+                "delay_minutes": 2.0,
+                "occupancy": "FEW_SEATS_AVAILABLE",
+                "latitude": 47.1,
+                "longitude": -122.1,
+            },
+        )
+        self.assertEqual(
+            attrs[sensor_module.ATTR_UPCOMING_DEPARTURES][1],
+            {
+                "due_at": "16:09",
+                "due_in": 9,
+                "delay_minutes": 5.0,
+                "occupancy": "STANDING_ROOM_ONLY",
+            },
+        )
+
     def test_stop_arrivals_failure_falls_back_to_trip_updates(self):
         data = PublicTransportData(
             trip_update_url="https://example.com/tripupdates.pb",


### PR DESCRIPTION
## Summary
- add a structured `Upcoming departures` attribute that exposes the next few trips while keeping the sensor state focused on the very next one
- keep the existing `Due at` and `Next bus` attributes for backward compatibility
- document the new attribute and add sensor coverage for the serialized departure list

## Testing
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall custom_components tests`