### PR TITLE
Avoid blocking Home Assistant startup

### DIFF
--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -5,7 +5,7 @@
     "dependencies": [],
     "codeowners": ["@Jason-Morcos"],
     "config_flow": true,
-    "version": "1.4.3",
+    "version": "1.4.4",
     "requirements": [
         "gtfs-realtime-bindings==1.0.0"
     ]

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -144,7 +144,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         "Move the feed under the top-level gtfs_rt section to enable route devices."
     )
     data = _build_shared_data(normalized)
-    add_devices(_build_sensors(data, normalized), True)
+    add_devices(_build_sensors(data, normalized), False)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -152,7 +152,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     config = dict(config_entry.data)
     data = _build_shared_data(config)
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = data
-    async_add_entities(_build_sensors(data, config, config_entry), True)
+    async_add_entities(_build_sensors(data, config, config_entry), False)
 
 
 class PublicTransportSensor(SensorEntity):
@@ -170,6 +170,10 @@ class PublicTransportSensor(SensorEntity):
         self._attr_icon = ICON
         self._attr_unique_id = str(unique_id) if unique_id else None
         self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
+
+    async def async_added_to_hass(self):
+        """Trigger an immediate refresh after startup without blocking entity setup."""
+        self.async_schedule_update_ha_state(True)
 
     def _get_next_buses(self):
         return self.data.info.get(self._route, {}).get(self._stop, [])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -301,5 +301,49 @@ class SensorUpdateTests(unittest.TestCase):
         self.assertIsNone(data.last_trip_update_error)
 
 
+class SensorStartupTests(unittest.IsolatedAsyncioTestCase):
+    async def test_async_setup_entry_does_not_force_update_before_add(self):
+        hass = types.SimpleNamespace(data={})
+        entry = types.SimpleNamespace(
+            entry_id="entry-1",
+            data={
+                const_module.CONF_TRIP_UPDATE_URL: "https://example.com/tripupdates.pb",
+                const_module.CONF_DEPARTURES: [
+                    {
+                        const_module.CONF_ROUTE: "100214",
+                        const_module.CONF_STOP_ID: "1234",
+                        const_mod.CONF_NAME: "Route 372",
+                        const_mod.CONF_UNIQUE_ID: "test-unique-id",
+                    }
+                ],
+            },
+        )
+        recorded = {}
+
+        def async_add_entities(entities, update_before_add=False):
+            recorded["entities"] = list(entities)
+            recorded["update_before_add"] = update_before_add
+
+        await sensor_module.async_setup_entry(hass, entry, async_add_entities)
+
+        self.assertEqual(recorded["update_before_add"], False)
+        self.assertEqual(len(recorded["entities"]), 1)
+
+    async def test_sensor_schedules_initial_refresh_after_being_added(self):
+        sensor = PublicTransportSensor(
+            data=types.SimpleNamespace(info={}, last_trip_update_error=None),
+            stop="1234",
+            route="100214",
+            name="Route 372",
+            unique_id="test-unique-id",
+        )
+        calls = []
+        sensor.async_schedule_update_ha_state = lambda force_refresh=False: calls.append(force_refresh)
+
+        await sensor.async_added_to_hass()
+
+        self.assertEqual(calls, [True])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- stop forcing GTFS entities to refresh before they are added during setup
- schedule the first refresh after entity registration so startup is not blocked by transit API or static schedule requests
- add startup-focused tests covering the non-blocking add flow and the initial refresh scheduling

## Testing
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `python3 -m compileall custom_components tests`