### PR TITLE
Pace stop-level arrivals requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ When the feed is configured under the top-level `gtfs_rt:` key, the integration 
 
 If both `trip_update_url` and `stop_arrivals_url_template` are configured, the stop-level arrivals endpoint is used as the primary realtime source and the trip-update feed remains available as a compatibility fallback in the configuration.
 
+Because the OneBusAway REST API is a stop-level endpoint and uses API-key throttling, the integration automatically deduplicates repeated stop IDs, warms the cache on startup, then refreshes only one unique stop per update cycle in round-robin order while honoring `Retry-After` on HTTP `429` responses. This reduces steady-state request volume for multi-stop feeds without requiring extra YAML tuning.
+
 The legacy `sensor: - platform: gtfs_rt` format still works, but it will not create route devices and is now considered deprecated.
 
 ## Screenshot

--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -5,7 +5,7 @@
     "dependencies": [],
     "codeowners": ["@Jason-Morcos"],
     "config_flow": true,
-    "version": "1.4.4",
+    "version": "1.4.5",
     "requirements": [
         "gtfs-realtime-bindings==1.0.0"
     ]

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -304,6 +304,14 @@ class PublicTransportData:
         self.last_trip_update_error = None
         self._schedule_status = {}
         self._last_stop_arrival_info = {}
+        self._stop_arrivals_routes_by_stop = {}
+        for route_id, stop_id in self._monitored_departures:
+            routes = self._stop_arrivals_routes_by_stop.setdefault(stop_id, [])
+            if route_id not in routes:
+                routes.append(route_id)
+        self._stop_arrivals_stop_ids = list(self._stop_arrivals_routes_by_stop)
+        self._stop_arrivals_last_refresh = {}
+        self._stop_arrivals_refresh_cursor = 0
         self._stop_arrivals_backoff_until = None
 
     def get_schedule_status(self, route_id, stop_id):
@@ -347,7 +355,11 @@ class PublicTransportData:
 
     def _update_stop_arrival_statuses(self):
         now = dt_util.now().replace(tzinfo=None)
-        cached_departures = self._future_departure_times(self._last_stop_arrival_info, now)
+        cached_departures = self._future_departure_times(
+            self._last_stop_arrival_info,
+            now,
+            self._monitored_departures,
+        )
 
         if self._stop_arrivals_backoff_until and now < self._stop_arrivals_backoff_until:
             self.info = cached_departures
@@ -358,23 +370,28 @@ class PublicTransportData:
                 f"{self._stop_arrivals_backoff_until.strftime(TIME_STR_FORMAT)}"
             )
 
-        departure_times = {}
+        departure_times = cached_departures
+        stop_ids_to_refresh = self._get_stop_ids_to_refresh(now)
 
-        for route_id, stop_id in self._monitored_departures:
-            departure_times.setdefault(route_id, {})
-            departure_times[route_id][stop_id] = []
+        if not stop_ids_to_refresh:
+            self.info = departure_times
+            self._last_stop_arrival_info = departure_times
+            return None
+
+        for stop_id in stop_ids_to_refresh:
             try:
                 url = self._stop_arrivals_url_template.format(stop_id=stop_id)
                 response = requests.get(url, headers=self._headers, timeout=REQUEST_TIMEOUT)
                 if response.status_code == 429:
                     retry_after = self._get_stop_arrivals_retry_after(response)
                     self._stop_arrivals_backoff_until = now + retry_after
-                    self.info = cached_departures
+                    self.info = departure_times
+                    self._last_stop_arrival_info = departure_times
                     _LOGGER.warning(
                         "Stop-level arrivals rate limited; backing off until %s",
                         self._stop_arrivals_backoff_until.strftime(TIME_STR_FORMAT),
                     )
-                    if self._has_departures(cached_departures):
+                    if self._has_departures(departure_times):
                         return None
                     return (
                         "Stop-level arrivals temporarily rate limited until "
@@ -394,18 +411,51 @@ class PublicTransportData:
 
             entry = (payload.get("data") or {}).get("entry") or {}
             arrivals = entry.get("arrivalsAndDepartures") or []
-            departure_times[route_id][stop_id] = filter_onebusaway_arrivals(arrivals, route_id, now)
+            for route_id in self._stop_arrivals_routes_by_stop.get(stop_id, []):
+                departure_times.setdefault(route_id, {})
+                departure_times[route_id][stop_id] = filter_onebusaway_arrivals(arrivals, route_id, now)
+            self._stop_arrivals_last_refresh[stop_id] = now
 
         self.info = departure_times
         self._last_stop_arrival_info = departure_times
         self._stop_arrivals_backoff_until = None
         return None
 
+    def _get_stop_ids_to_refresh(self, now):
+        if not self._stop_arrivals_stop_ids:
+            return []
+
+        refresh_interval = MIN_TIME_BETWEEN_UPDATES * len(self._stop_arrivals_stop_ids)
+        stale_stop_ids = [
+            stop_id
+            for stop_id in self._stop_arrivals_stop_ids
+            if stop_id not in self._stop_arrivals_last_refresh
+            or now - self._stop_arrivals_last_refresh[stop_id] >= refresh_interval
+        ]
+
+        if not stale_stop_ids:
+            return []
+
+        if len(self._stop_arrivals_last_refresh) < len(self._stop_arrivals_stop_ids):
+            return stale_stop_ids
+
+        for offset in range(len(self._stop_arrivals_stop_ids)):
+            index = (self._stop_arrivals_refresh_cursor + offset) % len(self._stop_arrivals_stop_ids)
+            stop_id = self._stop_arrivals_stop_ids[index]
+            if stop_id in stale_stop_ids:
+                self._stop_arrivals_refresh_cursor = (index + 1) % len(self._stop_arrivals_stop_ids)
+                return [stop_id]
+
+        return []
+
     @staticmethod
-    def _future_departure_times(departure_times, now):
+    def _future_departure_times(departure_times, now, monitored_departures=None):
         future_departures = {}
+        for route_id, stop_id in monitored_departures or []:
+            future_departures.setdefault(route_id, {})
+            future_departures[route_id].setdefault(stop_id, [])
         for route_id, stops in (departure_times or {}).items():
-            future_departures[route_id] = {}
+            future_departures.setdefault(route_id, {})
             for stop_id, details in stops.items():
                 future_departures[route_id][stop_id] = [
                     detail for detail in details if detail.arrival_time > now

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -300,6 +300,188 @@ class SensorUpdateTests(unittest.TestCase):
         self.assertEqual(data.info, {"100214": {"1234": ["departure"]}})
         self.assertIsNone(data.last_trip_update_error)
 
+    def test_stop_arrivals_dedupes_requests_for_shared_stops(self):
+        now = dt.datetime(2026, 4, 3, 16, 0, 0)
+        dt_mod.now = lambda: now
+        data = PublicTransportData(
+            trip_update_url="https://example.com/tripupdates.pb",
+            vehicle_position_url=None,
+            headers={},
+            monitored_departures=[("100214", "1234"), ("100225", "1234")],
+            static_schedule_url=None,
+            stop_arrivals_url_template="https://example.com/{stop_id}",
+        )
+        request_urls = []
+
+        class FakeResponse:
+            status_code = 200
+            headers = {}
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "code": 200,
+                    "data": {
+                        "entry": {
+                            "arrivalsAndDepartures": [
+                                {
+                                    "routeId": "1_100214",
+                                    "predictedDepartureTime": int(
+                                        (now + dt.timedelta(minutes=5)).timestamp() * 1000
+                                    ),
+                                    "scheduledDepartureTime": int(
+                                        (now + dt.timedelta(minutes=4)).timestamp() * 1000
+                                    ),
+                                },
+                                {
+                                    "routeId": "1_100225",
+                                    "predictedDepartureTime": int(
+                                        (now + dt.timedelta(minutes=8)).timestamp() * 1000
+                                    ),
+                                    "scheduledDepartureTime": int(
+                                        (now + dt.timedelta(minutes=7)).timestamp() * 1000
+                                    ),
+                                },
+                            ]
+                        }
+                    },
+                }
+
+        def fake_get(url, **_kwargs):
+            request_urls.append(url)
+            return FakeResponse()
+
+        sensor_module.requests.get = fake_get
+
+        data.update()
+
+        self.assertEqual(request_urls, ["https://example.com/1234"])
+        self.assertEqual(len(data.info["100214"]["1234"]), 1)
+        self.assertEqual(len(data.info["100225"]["1234"]), 1)
+        self.assertEqual(data.info["100214"]["1234"][0].arrival_time, now + dt.timedelta(minutes=5))
+        self.assertEqual(data.info["100225"]["1234"][0].arrival_time, now + dt.timedelta(minutes=8))
+
+    def test_bootstrapped_stop_arrivals_refresh_one_stop_per_update(self):
+        now = dt.datetime(2026, 4, 3, 16, 0, 0)
+        dt_mod.now = lambda: now
+        data = PublicTransportData(
+            trip_update_url="https://example.com/tripupdates.pb",
+            vehicle_position_url=None,
+            headers={},
+            monitored_departures=[("100214", "1234"), ("102732", "5678")],
+            static_schedule_url=None,
+            stop_arrivals_url_template="https://example.com/{stop_id}",
+        )
+        departure_a = StopDetails(now + dt.timedelta(minutes=4), None, None, None)
+        departure_b = StopDetails(now + dt.timedelta(minutes=7), None, None, None)
+        data._last_stop_arrival_info = {
+            "100214": {"1234": [departure_a]},
+            "102732": {"5678": [departure_b]},
+        }
+        data._stop_arrivals_last_refresh = {
+            "1234": now - dt.timedelta(minutes=2),
+            "5678": now - dt.timedelta(minutes=2),
+        }
+        request_urls = []
+
+        class FakeResponse:
+            status_code = 200
+            headers = {}
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"code": 200, "data": {"entry": {"arrivalsAndDepartures": []}}}
+
+        def fake_get(url, **_kwargs):
+            request_urls.append(url)
+            return FakeResponse()
+
+        sensor_module.requests.get = fake_get
+
+        data.update()
+        data.update()
+
+        self.assertEqual(
+            request_urls,
+            ["https://example.com/1234", "https://example.com/5678"],
+        )
+        self.assertEqual(data.info["102732"]["5678"], [])
+        self.assertEqual(data._stop_arrivals_last_refresh["1234"], now)
+        self.assertEqual(data._stop_arrivals_last_refresh["5678"], now)
+
+    def test_rate_limit_keeps_successful_partial_stop_arrivals_cache(self):
+        now = dt.datetime(2026, 4, 3, 16, 0, 0)
+        dt_mod.now = lambda: now
+        data = PublicTransportData(
+            trip_update_url="https://example.com/tripupdates.pb",
+            vehicle_position_url=None,
+            headers={},
+            monitored_departures=[("100214", "1234"), ("102732", "5678")],
+            static_schedule_url=None,
+            stop_arrivals_url_template="https://example.com/{stop_id}",
+        )
+        responses = []
+
+        class SuccessResponse:
+            status_code = 200
+            headers = {}
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "code": 200,
+                    "data": {
+                        "entry": {
+                            "arrivalsAndDepartures": [
+                                {
+                                    "routeId": "1_100214",
+                                    "predictedDepartureTime": int(
+                                        (now + dt.timedelta(minutes=6)).timestamp() * 1000
+                                    ),
+                                    "scheduledDepartureTime": int(
+                                        (now + dt.timedelta(minutes=5)).timestamp() * 1000
+                                    ),
+                                }
+                            ]
+                        }
+                    },
+                }
+
+        class RateLimitedResponse:
+            status_code = 429
+            headers = {"Retry-After": "120"}
+
+            def raise_for_status(self):
+                raise AssertionError("raise_for_status should not be called for 429 handling")
+
+        def fake_get(url, **_kwargs):
+            responses.append(url)
+            if url.endswith("/1234"):
+                return SuccessResponse()
+            return RateLimitedResponse()
+
+        sensor_module.requests.get = fake_get
+
+        result = data._update_stop_arrival_statuses()
+
+        self.assertIsNone(result)
+        self.assertEqual(
+            responses,
+            ["https://example.com/1234", "https://example.com/5678"],
+        )
+        self.assertEqual(
+            data.info["100214"]["1234"][0].arrival_time,
+            now + dt.timedelta(minutes=6),
+        )
+        self.assertEqual(data.info["102732"]["5678"], [])
+        self.assertEqual(data._stop_arrivals_backoff_until, now + dt.timedelta(seconds=120))
+
 
 class SensorStartupTests(unittest.IsolatedAsyncioTestCase):
     async def test_async_setup_entry_does_not_force_update_before_add(self):


### PR DESCRIPTION
## Summary
- dedupe stop-level arrivals requests by unique stop id and reuse a single response for all matching route sensors
- warm the stop-arrivals cache once, then refresh one stop per update cycle in round-robin order to reduce steady-state request volume
- keep successful partial cache data on 429 responses and document/test the new pacing behavior

## Testing
- python3 -m unittest discover -s tests -p 'test_*.py'
- python3 -m compileall custom_components tests